### PR TITLE
feat: improve query answer narrative

### DIFF
--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -54,7 +54,7 @@ func (e Engine) Answer(question string) (domain.Answer, error) {
 		return domain.Answer{}, fmt.Errorf("load contradictions for query: %w", err)
 	}
 
-	answerText := buildAnswerText(q, len(topEvents), len(claims), len(contradictions))
+	answerText := buildAnswerText(q, claims, contradictions, len(topEvents))
 	return domain.Answer{
 		AnswerText:       answerText,
 		Claims:           claims,
@@ -122,14 +122,26 @@ func collectContradictions(repo ports.RelationshipRepository, claims []domain.Cl
 	return result, nil
 }
 
-func buildAnswerText(question string, eventCount, claimCount, contradictionCount int) string {
-	return fmt.Sprintf(
-		"For %q, I found %d relevant events, %d related claims, and %d contradictions.",
-		question,
-		eventCount,
-		claimCount,
-		contradictionCount,
-	)
+func buildAnswerText(question string, claims []domain.Claim, contradictions []domain.Relationship, eventCount int) string {
+	if len(claims) == 0 {
+		return fmt.Sprintf("I could not find claims yet for %q. Try running extract/relate first.", question)
+	}
+
+	parts := []string{}
+	parts = append(parts, fmt.Sprintf("For %q, the strongest signal is: %s.", question, claims[0].Text))
+
+	if len(claims) > 1 {
+		parts = append(parts, fmt.Sprintf("Other relevant claim: %s.", claims[1].Text))
+	}
+
+	if len(contradictions) > 0 {
+		parts = append(parts, fmt.Sprintf("I also found %d contradiction(s), so this topic is contested.", len(contradictions)))
+	} else {
+		parts = append(parts, "No contradictions were found in the current claim set.")
+	}
+
+	parts = append(parts, fmt.Sprintf("Context used %d event(s) and %d claim(s).", eventCount, len(claims)))
+	return strings.Join(parts, " ")
 }
 
 func tokenSet(text string) map[string]struct{} {

--- a/internal/query/engine_test.go
+++ b/internal/query/engine_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -66,5 +67,11 @@ func TestAnswerIncludesClaimsAndContradictions(t *testing.T) {
 	}
 	if len(answer.TimelineEventIDs) == 0 {
 		t.Fatal("TimelineEventIDs should not be empty")
+	}
+	if !strings.Contains(answer.AnswerText, "strongest signal") {
+		t.Fatalf("AnswerText = %q, expected strongest signal narrative", answer.AnswerText)
+	}
+	if !strings.Contains(answer.AnswerText, "contested") {
+		t.Fatalf("AnswerText = %q, expected contradiction context", answer.AnswerText)
 	}
 }


### PR DESCRIPTION
## Summary
- replace count-only query answer text with a narrative answer that highlights strongest and secondary claims
- include contradiction context directly in the answer text when evidence is contested
- add a targeted test to lock the new answer behavior and prevent regressions

## Validation
- make check