### PR TITLE
deps: bump mcp-go v1.10.1 → v1.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/felixgeelhaar/axi-go v1.2.0
 	github.com/felixgeelhaar/bolt v1.4.0
 	github.com/felixgeelhaar/fortify v1.4.0
-	github.com/felixgeelhaar/mcp-go v1.10.1
+	github.com/felixgeelhaar/mcp-go v1.11.0
 	github.com/felixgeelhaar/statekit v1.5.0
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/felixgeelhaar/bolt v1.4.0 h1:DmgW+pzbQVziU1GEMiauzd8wPc9NLDzxwjj/LaAn
 github.com/felixgeelhaar/bolt v1.4.0/go.mod h1:Wr/OmSGrffzerUMz4a/0TAwxauvbQLRKe6ySMqejIqU=
 github.com/felixgeelhaar/fortify v1.4.0 h1:X9OVAOt4RaI2VF+svg/AhCW/2Sdt/TeJtluN68MZ/zw=
 github.com/felixgeelhaar/fortify v1.4.0/go.mod h1:n4jrh2iyz/0aKeUuLG99ZOPKNvsLQbMklZEmVpvPD4Y=
-github.com/felixgeelhaar/mcp-go v1.10.1 h1:U82abi+1ySKPfmFvosViEVY7ABnKsqEGcD31/tdmLSI=
-github.com/felixgeelhaar/mcp-go v1.10.1/go.mod h1:mCLPHMO/LdN3Eue77FZNi0veTi/TlcweEp0M5CI0Le4=
+github.com/felixgeelhaar/mcp-go v1.11.0 h1:rBYuYOIdso+DYU9l2khRlvczpiF5cI/0SXU7vRPRMy8=
+github.com/felixgeelhaar/mcp-go v1.11.0/go.mod h1:mCLPHMO/LdN3Eue77FZNi0veTi/TlcweEp0M5CI0Le4=
 github.com/felixgeelhaar/statekit v1.5.0 h1:SMOCQgmmcfoEbIdHKhpIKNgNVAwVQsscQ6RAi1bIezk=
 github.com/felixgeelhaar/statekit v1.5.0/go.mod h1:twgvJ2fyGUWjwAoWBsXM9b6FmUFj3yiJowlCkGHwHVQ=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

Pulls in the schema fix from felixgeelhaar/mcp-go#79: the schema generator now always emits \`properties\` for object schemas and writes \`additionalProperties: false\` for struct-derived schemas, making generated MCP tool schemas pass OpenAI strict tool-calling.

### Why this matters

Previously, \`mnemos__knowledge_metrics\` — our only zero-arg MCP tool — was rejected by OpenAI gpt-4o via OpenClaw with:

\`\`\`
400 Invalid schema for function 'mnemos__knowledge_metrics':
In context=(), object schema missing properties. (format)
\`\`\`

That rejection killed the entire tool list per request, so every agent turn that listed mnemos MCP tools failed before \`query_knowledge\` etc. were ever reached. Workaround on the host side was a hard-coded denylist of \`mnemos__knowledge_metrics\`.

With v1.11.0, the wire format from \`mnemos mcp\` automatically includes the missing \`properties\` key and marks struct-derived inputs as closed objects — no mnemos code changes required.

## Test plan

- [x] \`make check\` (fmt + vet + lint + race tests + build) green
- [x] \`go test -race -count=1 ./...\` all packages green
- [ ] Smoke test: \`mnemos mcp\` tool listing under an OpenAI-backed agent, confirm no 400 on tools.list