### PR TITLE
deps: bump mcp-go v1.11.0 → v1.11.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/felixgeelhaar/axi-go v1.2.0
 	github.com/felixgeelhaar/bolt v1.4.0
 	github.com/felixgeelhaar/fortify v1.4.0
-	github.com/felixgeelhaar/mcp-go v1.11.0
+	github.com/felixgeelhaar/mcp-go v1.11.2
 	github.com/felixgeelhaar/statekit v1.5.0
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/felixgeelhaar/bolt v1.4.0 h1:DmgW+pzbQVziU1GEMiauzd8wPc9NLDzxwjj/LaAn
 github.com/felixgeelhaar/bolt v1.4.0/go.mod h1:Wr/OmSGrffzerUMz4a/0TAwxauvbQLRKe6ySMqejIqU=
 github.com/felixgeelhaar/fortify v1.4.0 h1:X9OVAOt4RaI2VF+svg/AhCW/2Sdt/TeJtluN68MZ/zw=
 github.com/felixgeelhaar/fortify v1.4.0/go.mod h1:n4jrh2iyz/0aKeUuLG99ZOPKNvsLQbMklZEmVpvPD4Y=
-github.com/felixgeelhaar/mcp-go v1.11.0 h1:rBYuYOIdso+DYU9l2khRlvczpiF5cI/0SXU7vRPRMy8=
-github.com/felixgeelhaar/mcp-go v1.11.0/go.mod h1:mCLPHMO/LdN3Eue77FZNi0veTi/TlcweEp0M5CI0Le4=
+github.com/felixgeelhaar/mcp-go v1.11.2 h1:ZP7h2UN/c1PgsTSY8Q/eMkjbxe5LYQTUDyTsK6hTGx4=
+github.com/felixgeelhaar/mcp-go v1.11.2/go.mod h1:mCLPHMO/LdN3Eue77FZNi0veTi/TlcweEp0M5CI0Le4=
 github.com/felixgeelhaar/statekit v1.5.0 h1:SMOCQgmmcfoEbIdHKhpIKNgNVAwVQsscQ6RAi1bIezk=
 github.com/felixgeelhaar/statekit v1.5.0/go.mod h1:twgvJ2fyGUWjwAoWBsXM9b6FmUFj3yiJowlCkGHwHVQ=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

Picks up two MCP spec-compliance fixes shipped in [mcp-go v1.11.2](https://github.com/felixgeelhaar/mcp-go/releases/tag/v1.11.2) (PR felixgeelhaar/mcp-go#81):

- `time.Time` fields now generate `{type:"string",format:"date-time"}` schemas instead of recursing into the struct's unexported fields. Every `Claim.CreatedAt` / `Decision.ChosenAt` / `Lesson.At` etc. now agrees between the declared `outputSchema` and the actual runtime JSON.
- Typed-struct tool results (the common case in `cmd/mnemos/mcp.go` — every `srv.Tool(...).Handler` returns a concrete output struct, not `server.StructuredResult`) now populate `structuredContent` on the tools/call response when an `outputSchema` is declared, so strict MCP clients no longer reject the response with `-32600 Tool ... has an output schema but did not return structured content`.

No source changes needed in mnemos itself — purely a dependency bump.

## Test plan

- [x] `go mod tidy` clean.
- [x] `go build ./...` passes.
- [x] `go test -short ./cmd/mnemos/` passes.
- [x] End-to-end verified against an openclaw MCP runner: `query_knowledge` returns spec-compliant `structuredContent` with `CreatedAt` as RFC3339 strings; previously failing with two stacked schema errors.