### PR TITLE
docs(adr): cognitive-stack simplification — archive olymp/nous/praxis, extract decisionkit

### DIFF
--- a/.roady/spec.lock.json
+++ b/.roady/spec.lock.json
@@ -7,523 +7,687 @@
       "id": "core-foundation",
       "title": "Core Foundation",
       "description": "The essential building blocks of the project.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "documentation-ingestion-pipeline",
       "title": "Documentation Ingestion Pipeline",
       "description": "Create a documentation ingestion pipeline that accepts PRD/TDD and related project docs, normalizes and chunks content, stores metadata for traceability, and produces a searchable structured knowledge base used to drive Mnemos implementation planning.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-format-input-service",
       "title": "Multi-Format Input Service",
       "description": "Support ingestion of raw text and file-based inputs (TXT, MD, JSON, CSV), preserving source metadata and timestamps for downstream traceability.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "parser-and-event-normalization",
       "title": "Parser and Event Normalization",
       "description": "Normalize heterogeneous inputs into immutable events with schema versioning and source linkage, forming the canonical Input -\u003e Event transformation.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "append-only-event-store",
       "title": "Append-Only Event Store",
       "description": "Implement a local-first SQLite-backed append-only event store with indexes for timestamp and source input ID to support reliable replay and query foundations.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "claim-extraction-engine",
       "title": "Claim Extraction Engine",
       "description": "Derive structured claims (fact, hypothesis, decision) from events, enforce validation rules, and map each claim to at least one evidence event.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "relationship-detection-engine",
       "title": "Relationship Detection Engine",
       "description": "Detect support and contradiction relationships between claims within scoped comparisons and persist relationship edges for truth evolution analysis.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "cli-query-interface",
       "title": "CLI Query Interface",
       "description": "Provide a CLI query interface that returns structured answers with claims, surfaced contradictions, and an evidence-backed timeline.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "workflow-orchestration-and-observability",
       "title": "Workflow Orchestration and Observability",
       "description": "Track ingestion/extraction/relationship jobs through explicit workflow states with structured logging, retries, timeouts, and failure handling.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "claim-extraction-heuristics-v2",
       "title": "Claim Extraction Heuristics v2",
       "description": "Improve claim extraction quality by splitting event text into sentence-level candidate claims, deduplicating near-identical claims, and applying stronger heuristic scoring for fact/decision/hypothesis classification while preserving evidence traceability.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "sqlc-typed-data-access",
       "title": "SQLC Typed Data Access",
       "description": "Adopt sqlc for SQLite data-access to replace handwritten SQL in repositories with generated, typed query methods; include schema/queries layout, generation command, and initial migration of core event and claim reads/writes.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "sqlc-migration-phase-2",
       "title": "SQLC Migration Phase 2",
       "description": "Complete sqlc adoption by migrating relationship and compilation job repositories to generated typed queries, reducing handwritten SQL and unifying data access patterns.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "one-step-process-command",
       "title": "One-Step Process Command",
       "description": "Add a CLI `process` command that runs ingest, extract, and relate in one workflow for either file input or raw text, then prints IDs/counts so users can immediately run query without manual event ID lookups.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "run-scoped-querying",
       "title": "Run-Scoped Querying",
       "description": "Add run-scoped processing and querying so each process/ingest flow emits a run_id and query can restrict retrieval to a specific run, preventing cross-run context contamination in answers.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "llm-powered-claim-extraction",
       "title": "LLM-Powered Claim Extraction",
       "description": "Replace/augment rule-based extraction with LLM-powered claim extraction. Supports Anthropic, OpenAI, Google Gemini, Ollama, and any OpenAI-compatible provider. Activated via --llm flag with env var configuration. Falls back to rule-based extraction on LLM failure.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "markdown-preprocessing-and-structural-noise-filters",
       "title": "Markdown Preprocessing and Structural Noise Filters",
       "description": "Strip markdown formatting (bold, italic, strikethrough, links, bullets, checkboxes, headers) before claim extraction, and reject structural noise like label-value metadata rows, pipe-separated table rows, JSON fragments, short title-case headers, and email salutations. Raises extraction F1 on real-world documents from 79.9% to 87.8%.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "grounded-llm-answer-generation",
       "title": "Grounded LLM Answer Generation",
       "description": "When an LLM provider is configured, synthesize query answers from retrieved claims with inline citations instead of returning fixed templates. Falls back to template answers on LLM failure so offline/zero-config queries still work.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "claim-level-embeddings-and-cosine-reranking",
       "title": "Claim-Level Embeddings and Cosine Reranking",
       "description": "Generate vector embeddings for events and claims, store as little-endian float32 BLOBs in SQLite, and rerank query results by cosine similarity against the question embedding. Falls back to token-overlap ranking when no embedding provider is configured.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "project-scoped-database-with-init-subcommand",
       "title": "Project-Scoped Database with Init Subcommand",
       "description": "Add `mnemos init` to create a `.mnemos/` directory in the working directory. Database resolution walks up from CWD looking for `.mnemos/mnemos.db`, falling back to the XDG global default. MNEMOS_DB_PATH still wins outright. Discovery stops at the user's HOME to avoid adopting an unrelated parent project's DB.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "mcp-project-document-auto-ingest",
       "title": "MCP Project Document Auto-Ingest",
       "description": "When the MCP server starts inside a project (`.mnemos/` exists), bulk-ingest standard project documents — README, PRD, CHANGELOG, Roadmap, CLAUDE.md, ARCHITECTURE — plus the top level of `docs/` and recursive ADR conventions. Deduped via SQLite json_extract on event metadata source paths.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "file-watch-mcp-tool",
       "title": "File Watch MCP Tool",
       "description": "Expose a `watch_file` MCP tool that registers a path for re-ingestion when its content changes. Polling-based (5s, sha256 content comparison), in-memory state. Re-ingest reuses the same extract+relate pipeline as auto-ingest so agent edits flow into queryable claims with no manual step.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "knowledge-browsing-mcp-tools",
       "title": "Knowledge Browsing MCP Tools",
       "description": "Expose `list_claims`, `list_decisions`, and `list_contradictions` MCP tools for paginated read-only browsing of the knowledge base. Supports type/status filtering, pagination with sensible defaults, and claim-text hydration on the contradiction list via SQL JOIN.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "git-commit-context-auto-ingest",
       "title": "Git Commit Context Auto-Ingest",
       "description": "When the project root has a `.git` directory, read the most recent 50 commits via `git log` on MCP startup and persist each as an event with metadata (SHA, author, committed_at, subject). Commits flow through extract+relate so subjects and bodies become queryable claims. Deduped by SHA. Explicit `ingest_git_log` MCP tool exposes deeper history via limit/since.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "merged-pr-auto-ingest-via-gh-cli",
       "title": "Merged PR Auto-Ingest via gh CLI",
       "description": "When the gh CLI is installed and authenticated for github.com, auto-ingest the 20 most recent merged pull requests on MCP startup. PR titles and bodies flow through extract+relate so they become queryable claims. Deduped by PR number. Explicit `ingest_git_prs` MCP tool exposes configurable limit for deeper history. Silent no-op when gh is missing, unauth, or the repo is not on GitHub.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "knowledge-registry-server-(mnemos-serve)",
       "title": "Knowledge Registry Server (mnemos serve)",
       "description": "Add a `mnemos serve` subcommand that starts an HTTP API registry server backed by the same SQLite schema as the local client. The registry is the \"remote origin\" to each local project's \"local repo\" — users can push knowledge to a shared registry and pull from it at query time. Core endpoints cover event append, claim lookup, and relationship reads. Runs standalone or in a container.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "push/pull-synchronization-with-remote-registry",
       "title": "Push/Pull Synchronization with Remote Registry",
       "description": "Add `mnemos registry connect \u003curl\u003e` to wire a local project to a remote registry, plus push and pull semantics that mirror git's model. Push sends local events/claims/relationships to the registry; pull fetches remote knowledge and merges by source hash + run_id. Automatic sync hooks into process/query when enabled. Depends on Knowledge Registry Server.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "cross-project-query-federation",
       "title": "Cross-Project Query Federation",
       "description": "Extend the query engine to federate across the local database and one or more connected registries. Results include source provenance (local vs registry-name) so claims can be weighed by trust. Ranks cross-project results using the same cosine + token-overlap logic as local queries. Depends on Push/Pull Synchronization.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "registry-namespace-and-scope-isolation",
       "title": "Registry Namespace and Scope Isolation",
       "description": "Add namespace/scope primitives to the registry (team, org, project) so multiple tenants share a single server without leaking claims across boundaries. Push and pull operations carry a namespace context. Query federation respects the caller's accessible namespaces. Depends on Knowledge Registry Server.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "graphrag-multi-hop-query-support",
       "title": "GraphRAG Multi-Hop Query Support",
       "description": "Extend the query engine to traverse relationship edges at query time, enabling multi-hop questions like \"what decisions contradict the current approach to auth?\" that require walking from a seed claim through supports/contradicts chains. Reports the traversal path as part of the evidence trail.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "governance-and-compliance-layer",
       "title": "Governance and Compliance Layer",
       "description": "Add governance features to Mnemos as an enterprise-ready evidence layer: bias detection on claim sources, audit trails tracking who/when/why for every event and claim change, retention policies for aging out or archiving old events, and compliance export formats (CSV/JSON) for regulated environments.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "enterprise-integration-adapters",
       "title": "Enterprise Integration Adapters",
       "description": "Adapters that ingest content from common team knowledge surfaces: Slack threads, Microsoft Teams channels, Jira tickets, and Notion pages. Each adapter maps the source's identifiers into Mnemos event metadata so traceability survives the round trip. Adapters run as periodic jobs rather than real-time listeners to avoid webhook complexity.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "web-interface-on-registry-api",
       "title": "Web Interface on Registry API",
       "description": "Build a web UI that sits on top of the Phase 2B registry HTTP API — not a standalone app. Surfaces query, browsing, contradictions, and timeline views. Deferred until the registry API is proven with the CLI and MCP surfaces, per the \"API before UI\" principle established in the Phase 2A rewrite.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-foundation",
       "title": "Multi-Backend Storage Foundation",
       "description": "Replace the hard-wired SQLite construction with a pluggable storage layer per ADR 0001. Phase 1a: add `internal/store` driver registry with URL-scheme dispatch (`store.Open(ctx, dsn)`), repackage the existing SQLite implementation behind the registry as a `sqlite://` provider, ship a `memory://` in-process provider implementing the same `ports.*` interfaces (forces port purity, unblocks fast tests + Nous embedding), and widen `ports.EventRepository`/`ports.ClaimRepository` to the union of methods callers actually reach for. Subsequent phases (separate features): migrate cmd/mnemos and internal/pipeline call sites onto `store.Open`, add `MNEMOS_DB_URL`, add the Postgres provider with `pgvector`/`tsvector` and namespace isolation. Source: docs/adr/0001-multi-backend-storage.md.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-mnemos_db_url",
       "title": "Multi-Backend Storage MNEMOS_DB_URL",
       "description": "Phase 1b of ADR 0001: introduce a `MNEMOS_DB_URL` environment variable that takes precedence over `MNEMOS_DB_PATH` and is the canonical way to point Mnemos at any registered storage backend. Add a `resolveDSN()` helper in cmd/mnemos that returns the URL when set, otherwise wraps the legacy resolved file path as `sqlite:///\u003cpath\u003e`. Add an `openConn(ctx)` helper that calls `store.Open(ctx, resolveDSN())` so future call sites can switch by replacing two lines. Migrate the `mnemos doctor` deep-probe to use `openConn` as the proof-of-life consumer (it already exercises the deepest paths and is a natural smoke test for DSN resolution). Update help text + CLAUDE.md so MNEMOS_DB_URL appears alongside MNEMOS_DB_PATH. Mass call-site migration stays in a separate later phase.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-cmd/mnemos-call-site-migration",
       "title": "Multi-Backend Storage cmd/mnemos call site migration",
       "description": "Phase 1c of ADR 0001: migrate every production cmd/mnemos call site that does sqlite.Open(resolveDBPath()) onto a registry-mediated open. Add an openDB(ctx) helper that returns (*sql.DB, *store.Conn, error) — most cmd/mnemos surfaces still need the raw *sql.DB for entity/job repos and raw SQL paginations that aren't on the ports yet. Migration is mechanical: replace the open call, defer conn.Close instead of closeDB(db). Tests using fixed temp paths via sqlite.Open(filepath.Join(t.TempDir(), ...)) stay untouched — they're not on the resolveDBPath path. Result: every operator-facing CLI/MCP/server command honours MNEMOS_DB_URL (including future SQLite DSN options like ?busy_timeout=). Out of scope: lifting EntityRepository/CompilationJobRepository into ports (separate later phase), refactoring pipeline functions that take *sql.DB (separate later phase), Postgres provider (separate later phase).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-port-lift-entity-job",
       "title": "Multi-Backend Storage port lift Entity Job",
       "description": "Phase 2a of ADR 0001: lift EntityRepository and CompilationJobRepository from concrete SQLite types into ports interfaces, populate them on the Conn struct, and add memory provider implementations of both. After this phase, callers can use conn.Entities and conn.Jobs without reaching into the SQLite package, and memory:// can persist canonicalised entities and compilation_jobs the same way SQLite does. Pipeline refactor (PersistArtifacts / MaterializeEntities switching from *sql.DB to *store.Conn) and Postgres provider remain separate later phases.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-pipeline-port-refactor",
       "title": "Multi-Backend Storage pipeline port refactor",
       "description": "Phase 2b of ADR 0001: refactor pipeline.PersistArtifacts, pipeline.MaterializeEntities, pipeline.GenerateEmbeddings, pipeline.GenerateClaimEmbeddings to take *store.Conn instead of *sql.DB. Replace the cross-table SQLite transaction inside PersistArtifacts with sequential port-typed repository calls; per-table writes are still atomic in each backend. Trust scoring becomes optional via ports.TrustScorer type assertion. Update every caller in cmd/mnemos. Status-history attribution per claim is preserved by grouping claims by CreatedBy and calling UpsertWithReasonAs once per group. After this phase memory:// can run end-to-end ingest/process/embed paths. semantic_dedupe.go remains SQLite-specific (raw SQL probes) and is out of scope.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-call-site-cleanup",
       "title": "Multi-Backend Storage call site cleanup",
       "description": "Phase 2c of ADR 0001: drop the remaining sqlite.NewXxxRepository(db) constructions across cmd/mnemos in favor of conn.Xxx port-typed access. Trust scoring callers use ports.TrustScorer assertion. semantic_dedupe.go stays SQLite-specific (raw SQL probes) until a separate dedicated phase. Goal: cmd/mnemos imports internal/store/sqlite ONLY for blank-import provider registration after this phase.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-postgres-provider",
       "title": "Multi-Backend Storage Postgres provider",
       "description": "Phase 3 of ADR 0001: add internal/store/postgres/ provider implementing every port interface. Uses pgx/v5 + database/sql. Translates ?namespace= into CREATE SCHEMA IF NOT EXISTS + SET search_path. pgvector for VectorSearcher capability, tsvector for TextSearcher. Migrations live alongside the provider and run on Open. CI gains a Postgres job (docker-compose). Mirrors the contract validated by SQLite + memory in Phases 1-2.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-backend-agnostic-serve-and-dedupe",
       "title": "Multi-Backend Storage backend-agnostic serve and dedupe",
       "description": "Phase 4a of ADR 0001: migrate the last two SQLite-bound surfaces in mnemos to ports — `cmd/mnemos/serve.go` HTTP handlers (events/claims/relationships/embeddings/metrics) and `internal/pipeline/semantic_dedupe.go` (PlanSemanticDedupe + ApplySemanticDedupe). Use port-typed repositories where they exist; keep raw SQL paths only when no port-level alternative is available, and clearly mark them as SQLite-specific. After this phase no production cmd/mnemos or pipeline code reaches for sqlite.NewXxxRepository directly outside its own package.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-mysql-mariadb-provider",
       "title": "Multi-Backend Storage MySQL MariaDB provider",
       "description": "Phase 4b of ADR 0001: add internal/store/mysql/ provider implementing every port interface, registered for `mysql://` and `mariadb://` schemes. Uses github.com/go-sql-driver/mysql + database/sql. Per ADR 0001 §3, MySQL has no per-tenant schemas — namespace translates to \"use a separate database (CREATE DATABASE IF NOT EXISTS \u003cns\u003e; USE \u003cns\u003e)\". Schema SQL adapted: jsonb → JSON, bytea → LONGBLOB, bigserial → BIGINT AUTO_INCREMENT, timestamptz → DATETIME(6), now() → CURRENT_TIMESTAMP. Integration tests gated on TEST_MYSQL_DSN. MariaDB shares the wire protocol so the same provider serves both.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-ci-integration-job",
       "title": "Multi-Backend Storage CI integration job",
       "description": "Phase 5 of ADR 0001: lock in the Postgres and MySQL integration tests with a CI job. Add a `database-providers` GitHub Actions job that runs alongside the existing `Build \u0026 Test` job, spinning up postgres:16 + mysql:8 services and running `go test -race -count=1 ./internal/store/postgres/ ./internal/store/mysql/` with TEST_POSTGRES_DSN + TEST_MYSQL_DSN populated. Add a `make test-integration` target so developers can run the same suite locally.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-libsql-provider",
       "title": "Multi-Backend Storage libSQL provider",
       "description": "Phase 6 of ADR 0001: ship a libSQL/Turso provider for cloud-replicated and edge-deployable SQLite-compatible storage. Since libSQL is wire-compatible with SQLite, the provider reuses the existing sql/sqlite/schema.sql and the existing SQLite repository implementations — only the registration, DSN parsing, and sql.Open driver name change. Pure-Go driver (github.com/tursodatabase/libsql-client-go) keeps CGO_ENABLED=0. Supports both remote DSNs (libsql://my-db.turso.io?authToken=xyz) and local file DSNs (libsql:///tmp/test.db). Namespace param is ignored — each Turso database is its own tenant boundary, like plain SQLite. Plus a CLAUDE.md note that the existing postgres:// provider already serves any Postgres wire-protocol-compatible engine (CockroachDB, Yugabyte, Neon, Crunchy Bridge), no extra code needed.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "multi-backend-storage-everything-on-ports-legacy-cleanup",
       "title": "Multi-Backend Storage everything-on-ports legacy cleanup",
       "description": "Phase 7 of ADR 0001: every production surface is backend-agnostic; no legacy. Add the port methods needed to express semantic dedupe and the serve.go HTTP handlers without raw SQL — Claims.RepointEvidence, Claims.DeleteCascade, Relationships.RepointEndpoint, Relationships.DeleteByClaim, Embeddings.Delete, plus paginated list methods on Events/Claims/Relationships/Embeddings. Implement in every native provider (sqlite, memory, postgres, mysql; libsql inherits sqlite). Migrate pipeline.ApplySemanticDedupe and the serve.go handlers to ports. Then drop legacy: MNEMOS_DB_PATH env var, openDB helper (keep openConn only), sqlite.Open public function, any remaining sqlite-only call sites in cmd/mnemos. Pre-launch posture — no backwards-compat stubs.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "grpc-api-server",
       "title": "gRPC API Server",
       "description": "Add a gRPC API surface to Mnemos alongside the existing HTTP REST API. Define proto schemas for events, claims, relationships, and embeddings that mirror the HTTP API contract. Generate Go code with protoc-gen-go-grpc. Implement a gRPC server that reuses the existing port-typed repositories and bearer-token auth from serve.go. Wire into the CLI via `mnemos serve --grpc-port` or `mnemos grpc`. This enables high-performance service-to-service communication for the cognitive stack (Chronos, Praxis, Nous) and supports streaming for large dataset operations.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "causal-relationship-edges",
       "title": "Causal Relationship Edges",
       "description": "Phase 1 of evidence+causality+outcomes. Extend `relationships.kind` beyond supports/contradicts with: causes, caused_by, action_of, outcome_of, validates, refutes, derived_from. Domain: new RelKind* consts in internal/domain/types.go. internal/relate/engine.go: causal heuristic (action-verb claim t1 + state-change claim t2 with shared entities → causes) plus LLM extractor for ambiguous pairs. Query --hops gains --kind filter. Schema migration. Add evals/relate/causal/ with 20 cases. Foundation for outcomes, lessons, decisions, playbooks. No new entity types — pure edge-type expansion. Sequencing: ship before Action Outcomes since outcomes link via action_of/outcome_of edges.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "action-outcome-recording",
       "title": "Action Outcome Recording",
       "description": "Phase 2 of evidence+causality+outcomes. New domain types: Action{ID, Kind, Subject, Actor, RunID, At} and Outcome{ID, ActionID, Result, Metrics map[string]float64, ObservedAt}. Schema: actions, outcomes tables with FK to events. Two ingestion paths: (1) push API — `mnemos ingest --kind=action` + MCP `record_action`/`record_outcome` tools for agent-reported events; (2) pull adapters — Prometheus/OTel/log scrape under internal/adapters/outcomes/ for autonomous capture. Link Action↔Outcome via Phase 1 action_of/outcome_of edges. Required for Lessons synthesis (clusters action→outcome chains). Pull adapters can be incremental — ship at least one (Prometheus) with the push API.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "lessons-synthesis-engine",
       "title": "Lessons Synthesis Engine",
       "description": "Phase 3 — sharpest differentiator. New domain: Lesson{ID, Statement, Scope{Service,Env,Team}, Evidence []ActionID, Confidence, DerivedAt, LastVerified}. Schema: lessons + lesson_evidence tables, system-versioned per Phase 7 versioning best-practice. internal/synthesize/ engine clusters action→outcome chains by similarity + scope; emits Lesson when N≥3 corroborating with low contradiction. Confidence formula: corroboration_count × outcome_consistency × recency_weight. Brain-best-practice synthesis trigger — hybrid: incremental on-write (cheap consolidation, every claim ingest) + periodic batch (full re-cluster, sleep-like, configurable cron, default 24h) + manual `mnemos synthesize`. Query: `mnemos lessons --service=X --kind=Y`. MCP tool: `query_lessons`. Positioning anchor: \"evidence-based memory that learns from actions over time\".",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "temporal-validity-hardening",
       "title": "Temporal Validity Hardening",
       "description": "Phase 4. Strengthen existing valid_from/valid_to with stale-detection signals. Add columns: claims.last_verified, claims.verify_count, claims.half_life_days (per-claim override of hardcoded 90d default in internal/trust/trust.go). Surface staleness: Answer.StaleClaims[] in query results when freshness \u003c threshold. New CLI: `mnemos verify \u003cclaim\u003e` re-confirms against new events, bumps last_verified + verify_count, recomputes trust. Trust formula stays confidence × corroboration × freshness but freshness now uses per-claim half-life. Prevents stale-memory poisoning of agent decisions. No new entity types — column additions + CLI.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "decision-memory",
       "title": "Decision Memory",
       "description": "Phase 5. New domain: Decision{ID, Belief []ClaimID, Plan, Alternatives []string, Reasoning, RiskLevel, ChosenAt, OutcomeID *string}. Closes the loop: decision → action → outcome → validates/refutes belief claims. Schema: decisions table, FK to outcomes. Decision.OutcomeID links to Phase 2 Outcome — when set, Phase 1 validates/refutes edges fire automatically against Belief claim list. Audit query: `mnemos decision \u003cid\u003e` replays decision with retrieved evidence as it existed at ChosenAt (point-in-time using Phase 4 temporal validity). MCP tool: `record_decision`. Enables agent self-audit and reasoning improvement.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "playbook-synthesis",
       "title": "Playbook Synthesis",
       "description": "Phase 6. Direct compete with gbrain \"skills\" but derived not authored-from-scratch. Domain: Playbook{ID, Trigger, Steps []Step, Scope, DerivedFromLesson []LessonID, Confidence}. Steps as structured JSON contract — Mnemos returns steps only, Praxis executes (separation of concerns). Auto-synthesis in internal/synthesize/playbooks.go: cluster Phase 3 lessons by trigger pattern (e.g. \"latency_spike_after_deploy\" from N lessons matching that scope+kind) → emit playbook. Manual authoring also supported via markdown source-of-truth (overlaps with Phase 7). Query: `mnemos playbook \u003ctrigger\u003e`. MCP tool: `query_playbook`. Distinct from skills: playbooks have provenance back to lessons back to actions back to events.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "human-editable-markdown-layer-with-system-versioned-history",
       "title": "Human-Editable Markdown Layer with System-Versioned History",
       "description": "Phase 7. Markdown export-back loop for engineers to \"correct system memory\". CLI: `mnemos export --kind=lesson|claim|playbook [--scope=...]` emits Git-friendly markdown with stable IDs in frontmatter. `mnemos import \u003cfile.md\u003e` diffs against current state, creates new version row, fires extract+relate on changed text. Versioning best-practice: SQL:2011 system-versioned tables — append-only `*_versions` (claim_versions, lesson_versions, playbook_versions) with full row snapshot + valid_from/valid_to. Git-style deltas overcomplicate query. Audit-friendly, time-travel queries trivial: `WHERE @timestamp BETWEEN valid_from AND valid_to`. Schema migration adds versioning triggers in SQLite/Postgres/MySQL providers. Integrates with Phase 4 temporal validity.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "scope-aware-memory",
       "title": "Scope-Aware Memory",
       "description": "Phase 8. Multi-tenant scope beyond run_id and Postgres-schema namespace. Add scope JSONB column to claims, lessons, playbooks, decisions: {service, env, team, custom_tags}. Scope filter on every query, list, and synthesis path. Synthesis (Phase 3, 6) clusters strictly within scope to prevent cross-context noise. CLI: `--service=`, `--env=`, `--team=` flags on query/process/lessons/playbook. MCP: scope param on every tool. Indexes on scope JSON paths in each backend (SQLite json_extract, Postgres JSONB GIN, MySQL JSON functional). Defaults: when unset, all-scopes. Integrates with existing Agent.AllowedRuns whitelist.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "entity-aware-contradiction-detection",
       "title": "Entity-aware contradiction detection",
       "description": "The benchmark suite (`benchmarks/suites/contradiction_detection.py::three_way_partial_conflict`) shows Mnemos misses entity-level contradictions: \"The CEO is Alice\" + \"The CEO is Bob\" are not flagged as `contradicts`. F1 = 0.00 today.\n\nThe relate stage compares claim text via overlap heuristics; it has no concept of unique-role entities (one CEO per company at a time, one occupant per ID, etc.). Two claims that disagree about the same entity-attribute pair must surface as a contradiction even when their text overlap is low.\n\nAcceptance criteria:\n- New rule (or extension to existing rule) in `internal/relate` that:\n  1. Identifies the (subject, predicate) head of each claim (possibly with the help of `internal/extract`).\n  2. Pairs claims with the same (subject, predicate) but disagreeing object.\n  3. Emits a `contradicts` relationship between them.\n- Benchmark suite case `three_way_partial_conflict` improves from F1 0.00 to ≥ 0.80.\n- No regression on `direct_polarity_conflict` (must stay 1.00).\n- No false positive on `no_contradictions_clean_facts` (must stay precision 1.00).\n\nOut of scope:\n- Cross-language entity resolution.\n- Temporal validity (covered by the temporal-conflict feature).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "numeric-value-disagreement-detection",
       "title": "Numeric value disagreement detection",
       "description": "The benchmark suite (`benchmarks/suites/contradiction_detection.py::numeric_disagreement`) shows Mnemos misses numeric contradictions: \"The user has 12 prior refunds\" + \"The user has 0 prior refunds\" are not flagged as `contradicts`. F1 = 0.00 today.\n\nTwo claims that share an entity-attribute pair (e.g. \"user X has N prior refunds\") and have different numeric objects must surface as a contradiction. Today's text-overlap rule treats them as related but not contradicting because the numeric tokens are not equated against each other.\n\nAcceptance criteria:\n- Extension to `internal/relate` that:\n  1. Tokenises numeric values from each claim (integers, floats, units like \"ms\", \"%\", \"$\").\n  2. When two claims share entity+attribute and have different numeric values, emits `contradicts`.\n  3. Honours unit conversion where trivial (e.g. \"1 second\" vs \"1000 ms\" should not contradict).\n- Benchmark suite case `numeric_disagreement` improves from F1 0.00 to ≥ 0.80.\n- Tests in `internal/relate` covering int/float/unit combinations.\n- No regression on existing suite cases.\n\nOut of scope:\n- Statistical/range reasoning (\"around 12\" vs \"exactly 0\" — handle as separate roadmap item).\n- Currency conversion across symbols.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "implicit-temporal-contradiction-detection",
       "title": "Implicit temporal contradiction detection",
       "description": "The benchmark suite (`benchmarks/suites/contradiction_detection.py::implicit_temporal_conflict`) shows Mnemos misses implicit temporal contradictions: \"The migration completed on Tuesday\" + \"The migration is still running\" are not flagged as `contradicts`. F1 = 0.00 today.\n\nMnemos has temporal validity windows (`valid_from` / `valid_to`) but those only catch explicitly-dated supersession. Two claims about the same subject whose lexical aspects (perfect-completed vs progressive-still-running) imply mutual exclusion must surface as a contradiction.\n\nAcceptance criteria:\n- Extension to `internal/relate` (or `internal/extract` if aspect tagging belongs there) that:\n  1. Tags claims with one of {completed, ongoing, planned, never-happened}.\n  2. When two claims about the same subject have mutually-exclusive aspects (completed + ongoing for the same time window), emits `contradicts`.\n- Benchmark suite case `implicit_temporal_conflict` improves from F1 0.00 to ≥ 0.70 (lower bar — temporal reasoning is harder than entity/numeric).\n- No regression on existing suite cases.\n\nOut of scope:\n- Multi-step process modeling (\"started, then paused, then resumed\").\n- Calendar arithmetic (\"Tuesday\" → ISO week reasoning).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "benchmark-suite-in-ci-with-regression-gates",
       "title": "Benchmark suite in CI with regression gates",
       "description": "The benchmark harness at `benchmarks/` produces honest cross-product F1 numbers for contradiction detection (and future suites: replay completeness, evidence traceability, recall@k). To prevent silent regression as the relate stage evolves, the suite must run in CI on every PR with a regression gate.\n\nAcceptance criteria:\n- New GitHub Actions workflow `.github/workflows/benchmarks.yml` that:\n  1. Boots the benchmarks docker-compose stack (Mnemos only — competitor adapters can be skipped when API keys are absent).\n  2. Runs `python -m benchmarks.run --provider mnemos --suite all`.\n  3. Compares F1 vs the committed `benchmarks/RESULTS.md` (or a dedicated `benchmarks/baseline.json`).\n  4. Fails the workflow when F1 drops more than 0.05 on any suite.\n- README in `benchmarks/` documents how to update the baseline when an intentional improvement lands.\n- Workflow runtime under 5 minutes (so it doesn't gate normal PRs unreasonably).\n\nOut of scope:\n- Running competitor adapters in CI (cost, API key management).\n- Trend graphs / dashboards (separate roadmap item).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "published-cross-product-benchmarks-(locomo-+-longmemeval)",
       "title": "Published cross-product benchmarks (LoCoMo + LongMemEval)",
       "description": "All three primary competitors (mem0, zep/Graphiti, letta) cite published benchmark numbers as their adoption story. mem0 specifically reports LoCoMo 91.6, LongMemEval 93.4, BEAM 64.1. Mnemos's benchmarks today are a 5-case hand-authored contradiction-detection seed suite with F1=1.0 — meaningful for the wedge but not comparable to the leaderboards buyers cite.\n\nAcceptance criteria:\n- benchmarks/suites/longmemeval.py loads the published LongMemEval dataset and runs it against any registered Provider (mnemos, mem0, zep, letta — adapters land in their respective tasks).\n- benchmarks/suites/locomo.py same for LoCoMo.\n- benchmarks/results/ holds Mnemos's own numbers, comparable line-for-line with mem0's published claims.\n- benchmarks/RESULTS.md surfaces a head-to-head table.\n- README clearly states which numbers are reproduced from the original paper vs which we ran ourselves.\n\nOut of scope:\n- BEAM (low priority; LoCoMo + LongMemEval cover the same buyer concern).\n- Beating mem0 on every dataset (we run honestly; if Mnemos loses, the gap goes onto a roadmap).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "hybrid-retrieval-with-reranker",
       "title": "Hybrid retrieval with reranker",
       "description": "mem0's REST search supports semantic + BM25 + entity-linking with managed reranker; threshold/top_k/filter DSL (AND/OR/NOT/gte/lte/in/icontains). Graphiti's hybrid search adds graph-distance reranking. Mnemos has BM25 (when no embeddings) and embeddings + token overlap, but the paths are not unified and there is no documented filter DSL on /v1/claims or /v1/relationships.\n\nAcceptance criteria:\n- /v1/search endpoint that accepts {query, top_k, threshold, filters} and returns claims + their evidence + contradictions inline.\n- Filter DSL covers run_id, claim type, status, scope (service/env/team), valid_at, trust_score range, evidence count.\n- Score combines: cosine similarity (when embeddings configured) + BM25 + relationship-graph proximity (count of supports/contradicts edges away from query-matched seed claims).\n- Documented on the page + README.\n- Benchmarked: at least the recall@k metric on LongMemEval matches or beats Mnemos's current default.\n\nOut of scope:\n- ML reranker training (use a deterministic linear combo for now).\n- Cross-encoder reranking (separate task if the linear combo proves too weak).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "context-block-api-for-chat-agents",
       "title": "Context Block API for chat agents",
       "description": "Zep's headline feature: a single string \"Context Block\" that an agent can drop into its system prompt to get the relevant slice of user/thread history. Surveyed as the killer demo for chat-tuned use cases. Mnemos has all the underlying pieces (claims, lessons, playbooks, trust scores) but no single \"give me the context for thread X\" endpoint.\n\nAcceptance criteria:\n- /v1/context endpoint that accepts {run_id (or user_id), query?, max_tokens?} and returns a single string suitable for a system prompt: top-N claims by trust × relevance, surfaced contradictions, relevant lessons, optional thread summary.\n- Documented format with stable ordering so agents can rely on the layout.\n- mnemos-py wrapper method `Mnemos.context(run_id=…, query=…)` returns the same string.\n- Bench suite case: feed a chat history, call /v1/context, ensure the recalled facts answer a follow-up question correctly.\n\nOut of scope:\n- LLM-generated summary of the thread itself (use existing extracted claims for now; LLM summary is a follow-up).\n- Streaming context updates (one-shot is enough).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "bi-temporal-claim-model",
       "title": "Bi-temporal claim model",
       "description": "Graphiti tracks four timestamps per fact-edge: valid_at, invalid_at (event/validity time) + created_at, expired_at (transaction/ingestion time). This bi-temporal split is their headline differentiator. Mnemos has valid_from/valid_to but no separate ingestion-time axis — point-in-time queries today read the validity axis only.\n\nAcceptance criteria:\n- domain.Claim and domain.Relationship gain ingestion_time + ingestion_expired_at fields (event time stays as valid_from/valid_to).\n- /v1/claims supports `as_of=\u003ctimestamp\u003e` (validity time) AND `recorded_as_of=\u003ctimestamp\u003e` (ingestion time) filters independently.\n- mnemos query --at and --recorded-at flags expose both axes.\n- Migration script for existing claim rows (default ingestion_time = created_at).\n- Tests: a claim that was valid yesterday but recorded today returns under recorded_as_of=today AND as_of=yesterday simultaneously.\n\nOut of scope:\n- UI/dashboard for time-axis browsing.\n- Per-evidence ingestion timestamps (events already have ingested_at; this task is the claim/relationship layer only).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "entity-resolution-at-ingest",
       "title": "Entity resolution at ingest",
       "description": "Both mem0 (entity linking, replaced their removed graph store) and Graphiti (auto entity dedup at ingest) collapse references to the same real-world entity (e.g. \"Alice\", \"Alice Smith\", \"the CEO Alice\") into a canonical node. Mnemos has the entities CLI (entities list / show / merge) but no automatic resolution at ingest — claims with different surface forms of the same entity remain separate.\n\nAcceptance criteria:\n- internal/extract gains an entity-resolution pass: extracted claims are matched against the existing entities table by (name OR alias) + embedding similarity above a threshold, and merged into the canonical entity automatically.\n- A new claim that mentions \"Alice Smith\" links to the same entity row as an earlier claim mentioning \"Alice\" once the surface form has been seen.\n- Resolution decisions are auditable: each link records {claim_id, entity_id, score, method=exact|alias|embedding}.\n- The existing `mnemos entities merge` CLI continues to work for manual overrides.\n- Bench suite case: ingest \"The CEO is Alice\" then \"Alice owns the building\" and confirm both link to the same entity node.\n\nOut of scope:\n- Cross-language entity resolution.\n- LLM-driven entity resolution (rule-based + embedding similarity is enough for the first pass).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "epistemic-provenance-\u0026-claim-trust-framework",
       "title": "Epistemic Provenance \u0026 Claim Trust Framework",
       "description": "Implement epistemic provenance tracking to explain *why* a claim or data source is trusted over others, addressing user feedback on broad knowledge bases (e.g. Obsidian/Karpathy-style setups) needing trust differentiation. Covers two core areas:\n1. Source Credibility Signals: Score claim trustworthiness using link density (convergence across multiple resources), liveness (e.g. 12-year-old process doc still being actively executed), recency, authoritativeness, and citation graph analysis.\n2. Test Conflict Resolution: Resolve conflicting test results (e.g. Test1 passes, Test2 fails for same functionality) via test provenance (recency, authority), confidence-weighted resolution, and first-class \"which source/test to trust?\" query support.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "reliability-first-recall-hardening-(never-wrong-on-recall)",
       "title": "Reliability-first recall hardening (never wrong on recall)",
       "description": "Prioritize product trust strategy: \"never wrong on recall\". Add a reliability-first initiative that hardens retrieval/answering so factual recall is lossless and deterministic before any advanced synthesis expansion.\n\nScope:\n- Build a production eval harness using real anonymized conversation traces plus golden answers and required-substring assertions.\n- Enforce deterministic answer fallback: when generated answer omits required facts, return evidence-grounded claim text block.\n- Add confidence-calibrated answer policy with strict modes:\n  - high confidence + no conflict: concise direct answer\n  - low confidence or unresolved conflict: explicit uncertainty + evidence citations + escalation path\n- Add CI regression gates for recall metrics (hard fail on any drop beyond tolerance).\n- Add per-workspace memory quality telemetry: unresolved contradictions, stale claims, low-trust clusters, recall pass-rate trend.\n\nNon-goals:\n- New broad AI synthesis features.\n- Fancy UI redesign.\n\nSuccess metrics:\n- Recall pass-rate (required-substring) \u003e= 99% on held-out eval set.\n- Zero false factual omissions on golden critical set.\n- Regenerate rate and user correction rate decrease sprint-over-sprint.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "recall-hardening:-real-trace-eval-harness",
       "title": "Recall hardening: real-trace eval harness",
       "description": "Create a reproducible eval harness with anonymized real conversation traces, golden answers, required-substring assertions, and critical recall sets. Include train/validation/holdout split and deterministic runner.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "recall-hardening:-deterministic-evidence-fallback",
       "title": "Recall hardening: deterministic evidence fallback",
       "description": "Implement deterministic answer fallback in query path: when generated answer omits required evidence facts or falls below recall checks, return evidence-grounded claim text block with citations.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "recall-hardening:-confidence-calibrated-answer-policy",
       "title": "Recall hardening: confidence-calibrated answer policy",
       "description": "Add confidence-calibrated answer policy modes: direct answer for high-confidence/no-conflict, uncertainty mode for low-confidence/unresolved conflicts with explicit citations and escalation options.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "recall-hardening:-ci-regression-gates",
       "title": "Recall hardening: CI regression gates",
       "description": "Add CI benchmark gates for recall reliability with hard fail thresholds and baseline comparison. Enforce no-regression policy on required-substring recall and omission rate.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "recall-hardening:-memory-quality-telemetry",
       "title": "Recall hardening: memory quality telemetry",
       "description": "Add per-workspace memory quality telemetry: unresolved contradictions, stale claim ratio, low-trust clusters, recall pass-rate trend, and correction/regenerate proxies.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "recall-hardening:-rollout-guardrails-and-slos",
       "title": "Recall hardening: rollout guardrails and SLOs",
       "description": "Ship trust-focused documentation and rollout controls: feature flags, runbooks, acceptance checklist, and SLO definitions for never-wrong recall operation.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "public-/v1/leads-hardening:-rate-limit-+-email-validation-+-structured-logging",
       "title": "Public /v1/leads hardening: rate limit + email validation + structured logging",
       "description": "The public POST /v1/leads endpoint (cmd/mnemos/serve_auth.go:104-108 bypass + cmd/mnemos/serve.go:288-310 handler) has zero rate limiting, only a trivial `@` check, and writes the email verbatim to stderr via fmt.Fprintf — a DoS vector, log-injection vector, and GDPR-relevant PII exposure. Required: per-IP token-bucket limiter (golang.org/x/time/rate) with strict caps for /v1/leads; net/mail.ParseAddress + 254-char cap; reject CR/LF or non-printable bytes; hash-or-elide email in logs; route through bolt structured logger; explicit Origin/Referer allow-list for browser POSTs. Acceptance: chaos test sustaining 1k req/s for 60s does not exhaust process; emailed CRLF cannot forge log lines; logs contain no plaintext email.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "security-headers-middleware-(csp,-hsts,-x-frame-options,-x-content-type-options,-referrer-policy)",
       "title": "Security headers middleware (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy)",
       "description": "No security headers on any HTTP response (cmd/mnemos/serve.go:267 middleware chain — only panicRecover, access log, JWT auth). Landing page (cmd/mnemos/web/landing.html) executes inline JS and posts to /v1/leads with no CSP, no clickjacking protection, no XSS containment. Add a securityHeaders middleware setting: Content-Security-Policy (script-src 'self', form-action 'self', frame-ancestors 'none'), X-Content-Type-Options: nosniff, X-Frame-Options: DENY, Referrer-Policy: no-referrer, Strict-Transport-Security when TLS is enabled. Wire ahead of the auth middleware so it covers landing, registry SPA, and API. Acceptance: securityheaders.com scan ≥ A; integration test asserts CSP header present on /, /app, /v1/health.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "deduplicate-trust-signal-calculation-across-trust-+-query-packages",
       "title": "Deduplicate trust signal calculation across trust + query packages",
       "description": "Weight constants (0.50/0.15/0.13/0.10/0.05/0.07) and per-signal calculations are duplicated across internal/trust/credibility.go:98-105 and internal/query/engine.go:1800-1807 with a `must stay in sync` comment as the only governance — a fitness-function smell. Refactor: `trust.ScoreCredibility` returns (score float64, signals []domain.ProvenanceSignal, rationale string) directly. Delete provenanceSignals in engine.go. WhyTrustClaim consumes the structured breakdown. Add one test asserting WhyTrustClaim signals == ScoreCredibility breakdown bit-for-bit so future drift fails CI. Effort: small (~2h).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "claimrepository.listbytestrequirementref-port-+-index-for-trust-queries",
       "title": "ClaimRepository.ListByTestRequirementRef port + index for trust queries",
       "description": "cmd/mnemos/trust.go:48-59 and cmd/mnemos/mcp.go:1118 (which_test_to_trust) call Claims.ListAll(ctx) and filter by TestRequirementRef in Go — O(n) scan over the full claim corpus per invocation, with all 30+ columns marshaled over the wire on Postgres/MySQL. Add `ListByTestRequirementRef(ctx, ref string) ([]Claim, error)` to ports.ClaimRepository. Implement across sqlite, postgres, mysql, memory, libsql. Add `CREATE INDEX idx_claims_test_requirement_ref ON claims(type, test_requirement_ref) WHERE test_requirement_ref != ''` (and dialect equivalents). Update both call sites. Acceptance: bench with 100k claims shows \u003c50ms p95 vs current ListAll baseline.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "test-coverage-for-mnemos-trust-cli-and-which_test_to_trust-mcp-tool",
       "title": "Test coverage for mnemos trust CLI and which_test_to_trust MCP tool",
       "description": "Newly-shipped surface in cmd/mnemos/trust.go:19-130 and cmd/mnemos/mcp.go:1108-1182 (mcpRunWhichTestToTrust) has zero tests — verdict thresholds (0.05 ambiguous), requirement_ref validation, empty-candidate path, sort stability, JSON shape all unverified. The resolver path (pickTestWinner) is covered, but the surface above it isn't. Add table-driven tests for mcpRunWhichTestToTrust covering: winner clear-margin / ambiguous (\u003c0.05 gap) / no_candidates / missing requirement_ref. Use openConn against memory backend. Mirror as a cmd/mnemos handler test patterned on existing audit_test.go. Effort: small.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "eval-ci-regression-gate-across-extraction,-causal,-relationship,-longmem,-locomo-suites",
       "title": "Eval CI regression gate across extraction, causal, relationship, longmem, locomo suites",
       "description": ".github/workflows/benchmarks.yml:67-83 runs only --suite contradiction_detection. data/eval/*.yaml has 102 cases across extraction (90), causal_detection, relationship_detection running through go test with no F1/precision/recall floor — an LLM prompt change that drops extraction F1 from 0.92 to 0.55 still passes CI. Add `eval-gate` job that runs `go test ./data/eval/... -json` and a small Go check (or Python equivalent) comparing per-suite F1/precision/recall against data/eval/baseline.json floors, failing on \u003e5% drop. Extend to LongMemEval/LoCoMo when adapters are wired. This is the single biggest oracle gap in the repo.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "mutation-testing-on-internal/trust,-internal/relate,-internal/query",
       "title": "Mutation testing on internal/trust, internal/relate, internal/query",
       "description": "Coverage is ~90%+ but mutation kill-rate is unknown — `\u003e` flipped to `\u003c` in trust scoring may pass current tests, giving coverage illusion. Add go-mutesting (or ooze) over internal/trust, internal/relate, internal/query. Wire as a separate non-blocking CI job that posts the kill-rate as a PR comment. Block merges when internal/trust/ kill-rate falls below 70%. Document the threshold + rationale in a docs/testing/mutation.md. Effort: medium.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "api-surface-parity-fitness-function-(http-/-grpc-/-mcp)",
       "title": "API surface parity fitness function (HTTP / gRPC / MCP)",
       "description": "cmd/mnemos/mcp.go:448 registers which_test_to_trust; no equivalent route in cmd/mnemos/serve.go:248-261 or method in internal/server/grpc/server.go. Conway's Law signal — three transports own three definitions, each hand-maintained against a different mental model. Likely repeats with other recently-added tools. Step 1 (small): add a CI parity test enumerating (mcp_tool_name | http_route | grpc_method) triples and asserting set equality with an explicit allowlist for intentional gaps. Step 2 (medium, separate task): introduce internal/app/ use-case interfaces so HTTP/gRPC/MCP become 20-line transcoders.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "north-star-metric-+-opt-in-activation-telemetry",
       "title": "North Star metric + opt-in activation telemetry",
       "description": "Recall pass-rate (internal/query/engine.go:2006 MinRecallPassRate=0.95) is a quality floor, not an adoption metric. The product cannot answer \"is anyone getting value?\" — no time-to-first-value, no week-2 query retention, no regenerate-rate aggregation. Pick North Star: \"weekly active projects with ≥1 evidence-backed query.\" Instrument via existing MemoryQualityMetrics (engine.go:1921) plus daily rollup. Ship `mnemos metrics --workspace` view. Add opt-in anonymized telemetry POST to /v1/telemetry (random install_id, weekly_active_runs, queries, recall_pass_rate, regenerate_rate). Default off. Public dashboard at mnemos.dev/health once 10 workspaces opt in.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "honest-competitor-benchmarks-vs-mem0-/-zep-/-letta-on-longmemeval-+-locomo",
       "title": "Honest competitor benchmarks vs mem0 / zep / letta on LongMemEval + LoCoMo",
       "description": "benchmarks/suites/{longmemeval,locomo}.py scaffolds exist; benchmarks/RESULTS.md and baseline.json are present. Mem0 cites LongMemEval 93.4 / LoCoMo 91.6; Mnemos has no head-to-head numbers public. Wire mem0/zep adapters in benchmarks/, run all three providers on the published datasets, publish honest comparison in benchmarks/RESULTS.md. Link from README hero. If Mnemos loses on a suite, file the gap as a roadmap item — losing honestly beats not measuring. This is the strongest commercial wedge against leader-cited numbers.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "landing-positioning-+-demo-on-page-+-pricing-tiers-(gtm-unification)",
       "title": "Landing positioning + demo-on-page + pricing tiers (GTM unification)",
       "description": "Landing (cmd/mnemos/web/landing.html:6) sells \"Data Sovereignty \u0026 Compliance Platform\"; README.md:3 sells \"Self-hosted memory for AI apps.\" A GitHub visitor and a landing visitor get different products — category schizophrenia kills positioning. (1) Pick one lane: \"evidence layer for AI agents you actually own\" (where mem0/zep/letta compete); compliance becomes a wedge attribute, not the headline. Rewrite hero. (2) Add runnable code block / animated terminal showing `mnemos process --text \"...\"` → contradiction-detected JSON above the lead form. (3) Move README competitor comparison table onto landing as \"vs hosted memory services\" with one row per competitor. (4) Add 3-tier pricing strip: OSS (free, self-hosted) / Team (managed registry + SSO, waitlist) / Enterprise (audit, SLA, SOC2 — contact). (5) Replace adjective-soup social-proof section with real benchmark metrics linking to benchmarks/RESULTS.md. Effort: medium.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "operator-readable-trust-rationale-alongside-compact-metric-string",
       "title": "Operator-readable trust rationale alongside compact metric string",
       "description": "internal/trust/credibility.go:116-133 emits engineer-shorthand: \"base=0.62 authority=0.50 citations=3(0.42) recency=0.78 liveness=live agent_authority=1.00 test_decisiveness=8/10(0.60)\". CLAUDE.md positions this as the surface for non-technical operators via which_test_to_trust, but the string assumes the reader knows what citations=3(0.42) means. Ship a second prose rationale alongside the metric string: \"Last ran 12 days ago (fresh). Passed 8 of 10 runs (decisive). Live test. Authority not configured (assumed neutral).\" Keep compact form for tooling under score_breakdown; surface prose form as `rationale` in cmd/mnemos/trust.go and the WhichTestToTrust MCP output. Also: bump CLAUDE.md prompt v1.2 → v1.4 (matches internal/extract/prompt.go), add hybrid BM25+cosine note to README.md:97.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "jwt-kid-header-+-rotation;-scope/run-filter-on-trust-path",
       "title": "JWT kid header + rotation; scope/run filter on trust path",
       "description": "internal/auth/jwt.go:219-253 accepts only HS256 with no `kid` — dual-key rotation falls back to brute-trying the previous secret, masking real attacks in logs. internal/auth/secret.go:48-59 auto-generates a secret silently on first boot at a predictable path with no rotation prompt. Separately, cmd/mnemos/mcp.go:1118 (which_test_to_trust) and cmd/mnemos/trust.go:48 call Claims.ListAll without honoring the agent token's Scopes/Runs whitelist (jwt.go:51-97) — a low-privilege agent can enumerate test claims across runs/services it shouldn't see. Fix: include `kid` in JWT header, select verification key by kid, surface clearer rotation guidance when secret auto-generates. Thread actor scope/run whitelist into the trust path; filter candidates before scoring (or use the new ListByTestRequirementRef + scope filter).",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "postgres/mysql-connection-pool-tuning-+-llm-cache-eviction",
       "title": "Postgres/MySQL connection pool tuning + LLM cache eviction",
       "description": "internal/store/postgres/postgres.go:116-121 and internal/store/mysql/mysql.go:156-163 call sql.Open + PingContext but never tune SetMaxOpenConns/SetMaxIdleConns/SetConnMaxLifetime. Go default is unlimited open conns — exhausts Postgres max_connections (100) under MCP burst load and silently leaks idle conns. Set MaxOpenConns=25, MaxIdleConns=5, ConnMaxLifetime=30m, configurable via MNEMOS_DB_MAX_CONNS. Separately, internal/extract/llm_engine.go:295-307 stores cache JSON files under data/cache/llm-extraction/ with no TTL, LRU, or size cap — long-running ingestion grows unbounded and fills disk silently. Add MNEMOS_LLM_CACHE_MAX_BYTES (default 1 GiB) and a sweep on cache miss that evicts oldest by mtime until under cap. Also delete duplicate `idx_events_run_id` declaration in sql/sqlite/schema.sql:15-16.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "request-id-+-red-metrics-+-slo-doc-+-supply-chain-attestation",
       "title": "Request ID + RED metrics + SLO doc + supply-chain attestation",
       "description": "No correlation/request IDs across HTTP/MCP/pipeline (cmd/mnemos/serve_auth.go:173-188 boltAccessLog has no request_id/trace_id), making distributed tracing impossible. No /metrics Prometheus endpoint, no histogram of http_request_duration_seconds — operators cannot answer \"is mnemos healthy right now\" beyond /health. No SLO/error budget defined. Supply chain weak: .goreleaser.yaml has no SBOMs, no cosign signing, no SLSA provenance, dockers: only linux/amd64. Step 1 (small): add requestIDMiddleware (UUIDv7) injecting X-Request-ID into context; propagate to bolt log lines. Step 2 (medium): add prometheus/client_golang RED metrics on /internal/metrics; document SLO.md (p99\u003c250ms reads, 99.9% availability/30d). Step 3 (medium): add `sboms:`, `signs:` (cosign keyless), arm64+amd64 docker_manifests, slsa-framework/slsa-github-generator workflow.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "supply-chain-attestation:-sbom,-cosign-signing,-slsa-provenance,-arm64-docker",
       "title": "Supply-chain attestation: SBOM, cosign signing, SLSA provenance, arm64 docker",
       "description": "Step 3 of the original observability bundle, scoped to its own task because it's pure release pipeline work. .goreleaser.yaml has no `sboms:`, no `signs:` (cosign keyless), no SLSA provenance generator wiring, and `dockers:` only builds linux/amd64 — arm64 server users (Graviton, Apple-Silicon Linux) get no image. Add: `sboms: - artifacts: archive` for SPDX SBOM emission; `signs:` block with cosign keyless OIDC; switch `dockers:` to `docker_manifests:` covering amd64+arm64; add slsa-framework/slsa-github-generator workflow to produce SLSA L3 provenance for binaries and container images. Acceptance: `cosign verify-blob` passes against published archives; SBOM downloadable from GitHub release; arm64 image pulls from registry; SLSA provenance attached.",
-      "requirements": []
+      "requirements": [],
+      "source": {}
     },
     {
       "id": "jwt-kid-header-+-key-id-driven-verification",
       "title": "JWT kid header + key-id-driven verification",
       "description": "Split from the original observability+rotation bundle. internal/auth/jwt.go currently signs HS256 without a `kid` (key id) header. The dual-key Verifier (NewVerifierWithPrevious) brute-tries the previous secret on every signature error — when an attacker forges a wrong-but-plausible token the verifier silently consults both secrets, masking real attacks in logs. Add: include `kid` (an opaque short id, e.g. first 8 hex chars of SHA-256(secret)) in the JWT header on issue; select verification key by `kid` in NewVerifierWithPrevious; record the chosen key in audit logs so anomalous combinations surface; rotate kid on each LoadOrCreateSecret cycle. Tests cover (a) issue→verify happy path with kid, (b) rotation across two kids, (c) fabricated unknown-kid is rejected. Out of scope here: full asymmetric signing — HS256 stays.",
-      "requirements": null
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "archive-olymp-repo",
+      "title": "Archive olymp repo",
+      "description": "Tag olymp v0.1.5-final, replace README with redirect to mnemos + decisionkit, add DEPRECATED.md, set GitHub repo to archived. Zero Go consumers verified across siblings. Write ADR-001 in mnemos/docs/adr/001-archive-olymp.md citing the audit. Olymp's FSM loop, federation Peer, MCP tools, intent registry, and adapters all die with the repo (no extraction). Pre-archive grep across all business-felix-geelhaar/* go.mod files to confirm zero imports. Recoverable via tag.",
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "extract-decisionkit-library-from-nous",
+      "title": "Extract decisionkit library from nous",
+      "description": "Create new repo github.com/felixgeelhaar/decisionkit by copying nous/internal/risk/ + nous/internal/intervention/ verbatim with tests. Strip storage adapters, gRPC, LLM glue. Add decisionkit/mnemos adapter converting mnemos.Event into factor inputs. Maintain Nous's 90%+ test coverage as release gate. Cut v0.1.0. Write ADR-002 in mnemos/docs/adr/002-extract-decisionkit.md. Justification: Obvia needs deterministic risk + intervention scoring for compliance/cost/latency reasons; cannot be cleanly replaced by LLM calls.",
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "archive-nous-repo",
+      "title": "Archive nous repo",
+      "description": "After decisionkit ships, tag nous final, replace README with redirect to decisionkit, add DEPRECATED.md, set GitHub repo to archived. Nous's gRPC/HTTP transports, LLM extractor, multi-backend storage, and commitment service die with the repo. Only Olymp depended on Nous, and Olymp is already archived. Write ADR-003 in mnemos/docs/adr/003-archive-nous.md.",
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "mnemos-root-library-package-and-mnemos.new-entry-point",
+      "title": "Mnemos root library package and mnemos.New entry point",
+      "description": "Add a root-level public library API so external consumers (Hermes, Nomi, OpenClaw, NanoClaw, Claude Code via MCP, agent runtimes) can do `import \"github.com/felixgeelhaar/mnemos\"` and call `mnemos.New(opts...)`. Today mnemos is CLI/MCP/HTTP service only — no in-process library face exists. Create mnemos/memory.go with Memory interface (Remember, Recall, RememberEvent, Timeline), mnemos/new.go wiring internal/store + internal/pipeline + internal/query through the public surface, and mnemos/memory_impl.go binding methods. Touch nothing under internal/. Mark v0.x until 90 days of consumer feedback.",
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "framework-neutral-provider-interfaces-(textgenerator-and-embedder)",
+      "title": "Framework-neutral provider interfaces (TextGenerator and Embedder)",
+      "description": "Create new public mnemos/providers/ subpackage exporting TextGenerator and Embedder interfaces as thin wrappers around existing internal/llm.Client + internal/embedding.Client. Goal: agent runtimes (Hermes, Nomi, OpenClaw, NanoClaw, Claude Code, Codex, future frameworks) implement these as adapters around their own model clients. No Hermes-specific types in mnemos core. Verify no leaky provider details. Files: mnemos/providers/text.go, mnemos/providers/embedder.go.",
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "three-mode-option-builders-(passive,-sharedprovider,-enhanced)",
+      "title": "Three-mode option builders (Passive, SharedProvider, Enhanced)",
+      "description": "Implement mnemos/options.go with WithPassiveMode(), WithSharedProvider(tg, emb), WithEnhancedMode(cfg), WithChronos(c), WithStorage(dsn). Passive mode: no LLM, rule-based extraction + token-overlap query (zero env vars works). Shared provider: consumes external TextGenerator/Embedder from agent runtime. Enhanced: own LLM/embedding config. Passive must work out of the box — `mnemos.New()` with no args returns a working Memory. Sealed Option type prevents external impls.",
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "chronos-bundling-—-embedded-by-default-inside-mnemos.new",
+      "title": "Chronos bundling — embedded by default inside mnemos.New",
+      "description": "Import github.com/felixgeelhaar/chronos as Go dependency. mnemos.New() boots in-process Chronos by default (no separate server). WithChronos(c) lets advanced users supply their own instance. Storage stays separate: chronos.db adjacent to mnemos.db at XDG path (~/.local/share/mnemos/chronos.db) due to different mutation semantics (Chronos signals transient, Mnemos events immutable). Adapter at internal/temporal/chronos_adapter.go implements chronos.Source, maps mnemos.Event ↔ chronos.EntityState and chronos.Signal → mnemos.Claim. Chronos standalone (chronos.New()) remains unchanged for advanced users (incident timelines, audit trails, replay).",
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "temporal-mcp-tools-(remember_event,-timeline_query,-recall_at_time)",
+      "title": "Temporal MCP tools (remember_event, timeline_query, recall_at_time)",
+      "description": "Register three new MCP tools in cmd/mnemos/mcp.go: remember_event (ingest single event into Chronos), timeline_query (range queries by run_id/scope/window), recall_at_time (claims valid at an instant + evidence chain). Add CLI subcommand mnemos timeline at cmd/mnemos/timeline.go. Auto-synthesize claims from Chronos signals — when a Signal fires, adapter creates a corresponding Claim with signal.Confidence linked back via evidence. Conservative detector thresholds + aggregation windows; off by default, opt-in via WithChronosDetectors.",
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "refactor-cmd/mnemos-to-route-through-new-library",
+      "title": "Refactor cmd/mnemos to route through new library",
+      "description": "Refactor cmd/mnemos/mcp.go to use mnemos.New() instead of raw repository wiring. All 25 existing MCP tools must continue to pass (no behavior change, routing only). Also refactor cmd/mnemos/process.go, query.go, ingest.go to use library where reasonable while keeping CLI flag parsing in cmd. Public docs at mnemos/docs/library.md with 3-mode examples + Go playground-ready snippets. Godoc examples in mnemos/example_test.go (Example_passive, Example_sharedProvider, Example_enhanced, Example_withChronos). Integration tests in mnemos/memory_test.go covering all 3 modes end-to-end + zero-config bootstrap test.",
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "obvia-inline-migration-off-praxis",
+      "title": "Obvia inline migration off Praxis",
+      "description": "Replace obvia/internal/application/remediation/praxis.go (HTTP client) with inline orchestration. Copy idempotency keeper (~25 LOC) from praxis/internal/idempotency/, outbox emitter from praxis/internal/outcome/ (adapt to talk to mnemos directly), audit trail from praxis/internal/audit/, policy engine from praxis/internal/policy/ only if Obvia uses it (verify by grep). Vendor calls use direct SDKs (slack-go, go-github). Delete obvia/deploy/docker-compose/chaos/cmd/praxis-runtime/ stub. Update Obvia integration tests to exercise inline backend. Single PR, straight cutover — no feature flag because Obvia is dogfooding only with no external users.",
+      "requirements": [],
+      "source": {}
+    },
+    {
+      "id": "archive-praxis-repo",
+      "title": "Archive praxis repo",
+      "description": "Immediately after Obvia inline PR merges, tag praxis v0.3.1-final, replace README with redirect to mnemos + actionkit-not-extracted note (explain Obvia inlined the orchestration primitives, vendor handlers belong to agents via MCP), add DEPRECATED.md, set GitHub repo to archived. Praxis's HTTP/gRPC API, out-of-process plugin host + Fulcio signing, 6 vendor handlers (Slack/GitHub/Linear/HTTP/Calendar/Email), capability registry, MCP server all die with the repo. Pre-archive grep all siblings for praxis host config to verify zero forgotten consumers beyond Obvia. Write ADR-004 in mnemos/docs/adr/004-archive-praxis.md.",
+      "requirements": null,
+      "source": {}
     }
   ],
   "constraints": [],

--- a/.roady/spec.yaml
+++ b/.roady/spec.yaml
@@ -491,5 +491,49 @@ features:
       title: JWT kid header + key-id-driven verification
       description: 'Split from the original observability+rotation bundle. internal/auth/jwt.go currently signs HS256 without a `kid` (key id) header. The dual-key Verifier (NewVerifierWithPrevious) brute-tries the previous secret on every signature error — when an attacker forges a wrong-but-plausible token the verifier silently consults both secrets, masking real attacks in logs. Add: include `kid` (an opaque short id, e.g. first 8 hex chars of SHA-256(secret)) in the JWT header on issue; select verification key by `kid` in NewVerifierWithPrevious; record the chosen key in audit logs so anomalous combinations surface; rotate kid on each LoadOrCreateSecret cycle. Tests cover (a) issue→verify happy path with kid, (b) rotation across two kids, (c) fabricated unknown-kid is rejected. Out of scope here: full asymmetric signing — HS256 stays.'
       requirements: []
+    - id: archive-olymp-repo
+      title: Archive olymp repo
+      description: Tag olymp v0.1.5-final, replace README with redirect to mnemos + decisionkit, add DEPRECATED.md, set GitHub repo to archived. Zero Go consumers verified across siblings. Write ADR-001 in mnemos/docs/adr/001-archive-olymp.md citing the audit. Olymp's FSM loop, federation Peer, MCP tools, intent registry, and adapters all die with the repo (no extraction). Pre-archive grep across all business-felix-geelhaar/* go.mod files to confirm zero imports. Recoverable via tag.
+      requirements: []
+    - id: extract-decisionkit-library-from-nous
+      title: Extract decisionkit library from nous
+      description: 'Create new repo github.com/felixgeelhaar/decisionkit by copying nous/internal/risk/ + nous/internal/intervention/ verbatim with tests. Strip storage adapters, gRPC, LLM glue. Add decisionkit/mnemos adapter converting mnemos.Event into factor inputs. Maintain Nous''s 90%+ test coverage as release gate. Cut v0.1.0. Write ADR-002 in mnemos/docs/adr/002-extract-decisionkit.md. Justification: Obvia needs deterministic risk + intervention scoring for compliance/cost/latency reasons; cannot be cleanly replaced by LLM calls.'
+      requirements: []
+    - id: archive-nous-repo
+      title: Archive nous repo
+      description: After decisionkit ships, tag nous final, replace README with redirect to decisionkit, add DEPRECATED.md, set GitHub repo to archived. Nous's gRPC/HTTP transports, LLM extractor, multi-backend storage, and commitment service die with the repo. Only Olymp depended on Nous, and Olymp is already archived. Write ADR-003 in mnemos/docs/adr/003-archive-nous.md.
+      requirements: []
+    - id: mnemos-root-library-package-and-mnemos.new-entry-point
+      title: Mnemos root library package and mnemos.New entry point
+      description: Add a root-level public library API so external consumers (Hermes, Nomi, OpenClaw, NanoClaw, Claude Code via MCP, agent runtimes) can do `import "github.com/felixgeelhaar/mnemos"` and call `mnemos.New(opts...)`. Today mnemos is CLI/MCP/HTTP service only — no in-process library face exists. Create mnemos/memory.go with Memory interface (Remember, Recall, RememberEvent, Timeline), mnemos/new.go wiring internal/store + internal/pipeline + internal/query through the public surface, and mnemos/memory_impl.go binding methods. Touch nothing under internal/. Mark v0.x until 90 days of consumer feedback.
+      requirements: []
+    - id: framework-neutral-provider-interfaces-(textgenerator-and-embedder)
+      title: Framework-neutral provider interfaces (TextGenerator and Embedder)
+      description: 'Create new public mnemos/providers/ subpackage exporting TextGenerator and Embedder interfaces as thin wrappers around existing internal/llm.Client + internal/embedding.Client. Goal: agent runtimes (Hermes, Nomi, OpenClaw, NanoClaw, Claude Code, Codex, future frameworks) implement these as adapters around their own model clients. No Hermes-specific types in mnemos core. Verify no leaky provider details. Files: mnemos/providers/text.go, mnemos/providers/embedder.go.'
+      requirements: []
+    - id: three-mode-option-builders-(passive,-sharedprovider,-enhanced)
+      title: Three-mode option builders (Passive, SharedProvider, Enhanced)
+      description: 'Implement mnemos/options.go with WithPassiveMode(), WithSharedProvider(tg, emb), WithEnhancedMode(cfg), WithChronos(c), WithStorage(dsn). Passive mode: no LLM, rule-based extraction + token-overlap query (zero env vars works). Shared provider: consumes external TextGenerator/Embedder from agent runtime. Enhanced: own LLM/embedding config. Passive must work out of the box — `mnemos.New()` with no args returns a working Memory. Sealed Option type prevents external impls.'
+      requirements: []
+    - id: chronos-bundling-—-embedded-by-default-inside-mnemos.new
+      title: Chronos bundling — embedded by default inside mnemos.New
+      description: 'Import github.com/felixgeelhaar/chronos as Go dependency. mnemos.New() boots in-process Chronos by default (no separate server). WithChronos(c) lets advanced users supply their own instance. Storage stays separate: chronos.db adjacent to mnemos.db at XDG path (~/.local/share/mnemos/chronos.db) due to different mutation semantics (Chronos signals transient, Mnemos events immutable). Adapter at internal/temporal/chronos_adapter.go implements chronos.Source, maps mnemos.Event ↔ chronos.EntityState and chronos.Signal → mnemos.Claim. Chronos standalone (chronos.New()) remains unchanged for advanced users (incident timelines, audit trails, replay).'
+      requirements: []
+    - id: temporal-mcp-tools-(remember_event,-timeline_query,-recall_at_time)
+      title: Temporal MCP tools (remember_event, timeline_query, recall_at_time)
+      description: 'Register three new MCP tools in cmd/mnemos/mcp.go: remember_event (ingest single event into Chronos), timeline_query (range queries by run_id/scope/window), recall_at_time (claims valid at an instant + evidence chain). Add CLI subcommand mnemos timeline at cmd/mnemos/timeline.go. Auto-synthesize claims from Chronos signals — when a Signal fires, adapter creates a corresponding Claim with signal.Confidence linked back via evidence. Conservative detector thresholds + aggregation windows; off by default, opt-in via WithChronosDetectors.'
+      requirements: []
+    - id: refactor-cmd/mnemos-to-route-through-new-library
+      title: Refactor cmd/mnemos to route through new library
+      description: Refactor cmd/mnemos/mcp.go to use mnemos.New() instead of raw repository wiring. All 25 existing MCP tools must continue to pass (no behavior change, routing only). Also refactor cmd/mnemos/process.go, query.go, ingest.go to use library where reasonable while keeping CLI flag parsing in cmd. Public docs at mnemos/docs/library.md with 3-mode examples + Go playground-ready snippets. Godoc examples in mnemos/example_test.go (Example_passive, Example_sharedProvider, Example_enhanced, Example_withChronos). Integration tests in mnemos/memory_test.go covering all 3 modes end-to-end + zero-config bootstrap test.
+      requirements: []
+    - id: obvia-inline-migration-off-praxis
+      title: Obvia inline migration off Praxis
+      description: Replace obvia/internal/application/remediation/praxis.go (HTTP client) with inline orchestration. Copy idempotency keeper (~25 LOC) from praxis/internal/idempotency/, outbox emitter from praxis/internal/outcome/ (adapt to talk to mnemos directly), audit trail from praxis/internal/audit/, policy engine from praxis/internal/policy/ only if Obvia uses it (verify by grep). Vendor calls use direct SDKs (slack-go, go-github). Delete obvia/deploy/docker-compose/chaos/cmd/praxis-runtime/ stub. Update Obvia integration tests to exercise inline backend. Single PR, straight cutover — no feature flag because Obvia is dogfooding only with no external users.
+      requirements: []
+    - id: archive-praxis-repo
+      title: Archive praxis repo
+      description: Immediately after Obvia inline PR merges, tag praxis v0.3.1-final, replace README with redirect to mnemos + actionkit-not-extracted note (explain Obvia inlined the orchestration primitives, vendor handlers belong to agents via MCP), add DEPRECATED.md, set GitHub repo to archived. Praxis's HTTP/gRPC API, out-of-process plugin host + Fulcio signing, 6 vendor handlers (Slack/GitHub/Linear/HTTP/Calendar/Email), capability registry, MCP server all die with the repo. Pre-archive grep all siblings for praxis host config to verify zero forgotten consumers beyond Obvia. Write ADR-004 in mnemos/docs/adr/004-archive-praxis.md.
+      requirements: []
 constraints: []
 version: 0.1.0

--- a/docs/adr/0003-archive-olymp.md
+++ b/docs/adr/0003-archive-olymp.md
@@ -1,0 +1,124 @@
+# ADR 0003: Archive Olymp
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Deciders:** Felix Geelhaar
+- **Scope:** Cognitive stack repository topology. No code changes inside Mnemos.
+
+## Context
+
+The cognitive stack was historically organised around five primitives:
+
+- Mnemos — memory
+- Chronos — time / events
+- Nous — reasoning
+- Praxis — action
+- Olymp — orchestration
+
+Olymp implemented a closed-loop finite state machine
+(`observe → understand → decide → act → learn`) wired across the other four
+tools, with runtime steering (pause/approve/cancel), federation via a
+`plugin.Peer` interface, a typed intent registry, provenance auditing, and
+an MCP surface (`submit_intent`, `inspect_run`, `steer_run`, `halt`, ...).
+
+A repository audit on 2026-05-31 produced two findings that change the
+calculus for keeping Olymp alive:
+
+1. **Reasoning has moved into the agent layer.** Frontier models plus modern
+   agent SDKs (Claude Code, Codex, Hermes, Nomi, OpenClaw, NanoClaw, ...)
+   subsume the orchestration patterns Olymp was built to provide. Single-
+   agent tool use, agent subagents, and external frameworks like CrewAI /
+   AutoGen / LangGraph cover the 80% case without a separate runtime.
+2. **Olymp has zero Go importers anywhere in the org.** Grep across all
+   `business-felix-geelhaar/*/go.mod` and `*.go` files outside Olymp itself
+   returns zero matches. Olymp is referenced narratively in some sibling
+   READMEs but no code depends on it.
+
+Olymp also remains coupled to Nous (its decision port) and Praxis (its
+action port), both of which we are independently archiving (ADRs 0005 and
+0006). Keeping Olymp alive would require finding it new ports, with no
+existing consumer asking for them.
+
+## Decision
+
+We will archive the Olymp repository. The repo stays publicly readable but
+is set to read-only on GitHub and tagged `v0.1.5-final`. Its README is
+replaced with a redirect explaining the new architecture (Mnemos + Chronos
++ agent runtimes), and a `DEPRECATED.md` is added at the repo root with the
+rationale and the recovery path.
+
+We do **not** extract any Olymp code into a new library:
+
+- The closed-loop FSM is a reusable pattern but has no current consumer.
+  If a future consumer materialises, the pattern can be re-derived into
+  `statekit/loop` from the archived source.
+- Federation `plugin.Peer` is interesting for multi-runtime delegation but
+  is solving a problem (cross-agent coordination) that the agent layer is
+  expected to own going forward.
+- The MCP tool surface (`submit_intent`, etc.) is design-specific to
+  Olymp's intent registry. Each agent runtime will expose whatever MCP
+  surface makes sense for its own loop, backed by mnemos / chronos calls.
+- The provenance audit trail is partially duplicated by mnemos action /
+  outcome events (Phase 2) and partially replaceable by structured agent
+  transcripts.
+
+## Consequences
+
+**Positive:**
+
+- The cognitive-stack story collapses from five primitives to three
+  (mnemos / chronos / agent runtime). New developers can grasp it in under
+  60 seconds without learning Olymp's loop model.
+- No upstream consumer breaks (zero importers).
+- Releases the v0.1.5 line as a reference if someone wants to fork the
+  loop FSM later.
+
+**Negative / risks:**
+
+- We lose the prebuilt MCP surface for runtime steering. Each agent runtime
+  reimplements pause/resume/approve on its own. Mitigation: the patterns
+  are well documented in Olymp's README and source; we accept the cost.
+- A future user wanting Olymp's exact orchestration shape will need to
+  resurrect from the tag. Acceptable: the cost of revival is bounded;
+  the cost of keeping a maintained-but-unused service is unbounded.
+
+## Pre-archive verification
+
+Pre-archive grep across `/Users/felixgeelhaar/Developer/projects/business-felix-geelhaar/*`:
+
+```
+grep -rln '"github.com/felixgeelhaar/olymp' --include='*.go' --exclude-dir=olymp .
+→ 0 matches
+
+grep -rln 'felixgeelhaar/olymp' --include='go.mod' --include='go.sum' --exclude-dir=olymp .
+→ 0 matches
+```
+
+No code depends on Olymp.
+
+## Migration path
+
+Nothing to migrate. Olymp's adapters under `olymp/internal/adapters/{nous,praxis,mnemos,chronos}`
+die with the repo (Nous and Praxis are also being archived under ADRs 0005
+and 0006; Mnemos and Chronos remain).
+
+## Alternatives Considered
+
+**1. Keep Olymp alive as a reference implementation.**
+Rejected. Maintained code rots; reference code is a tag.
+
+**2. Extract `statekit/loop` and `statekit/federation` from Olymp now.**
+Rejected. No current consumer. Extracting on speculation grows the surface
+to maintain without any caller exercising the API. If a real consumer
+emerges, the patterns can be lifted from the archived tag.
+
+**3. Fold Olymp into Hermes (or another agent runtime).**
+Rejected. Mnemos must work with any agent runtime, not be Hermes-specific.
+Folding Olymp into Hermes contaminates the runtime-neutral architecture
+goal that drove this simplification.
+
+## Related Work
+
+- [ADR 0004: Extract decisionkit](0004-extract-decisionkit.md)
+- [ADR 0005: Archive Nous](0005-archive-nous.md)
+- [ADR 0006: Archive Praxis](0006-archive-praxis.md)

--- a/docs/adr/0004-extract-decisionkit.md
+++ b/docs/adr/0004-extract-decisionkit.md
@@ -1,0 +1,126 @@
+# ADR 0004: Extract decisionkit from Nous
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Deciders:** Felix Geelhaar
+- **Scope:** New standalone repository `github.com/felixgeelhaar/decisionkit`.
+  Source code lifted from `nous/internal/risk/` and `nous/internal/intervention/`.
+  Prerequisite to archiving Nous (ADR 0005).
+
+## Context
+
+We are archiving Nous (ADR 0005) as part of the cognitive-stack
+simplification. Most of Nous's value (LLM extraction, gRPC/HTTP transport,
+multi-backend storage, service shell) is replaceable by agent runtimes plus
+Mnemos and dies with the repo.
+
+Two packages inside Nous have unique, non-replaceable value:
+
+1. **`internal/risk/`** — a deterministic, weighted, explainable risk
+   scorer. Inputs: a set of factors (overdue, due-soon, confidence,
+   external signals). Output: a score with a per-factor breakdown that an
+   operator can read. Pure functions, no I/O, no LLM.
+2. **`internal/intervention/`** — a threshold-based policy engine mapping
+   risk scores to intervention levels (nudge / escalate / automation),
+   with confidence-aware routing to avoid auto-remediation on low-confidence
+   inputs.
+
+These are not LLM wrappers. They are domain logic with a 90%+ test suite.
+Obvia (our remediation system, the only programmatic consumer in scope)
+needs deterministic scoring for three load-bearing reasons:
+
+- **Compliance.** The risk score's per-factor breakdown is an auditable
+  rationale. An LLM judgement is opaque.
+- **Cost.** Scoring runs on every observation. LLM calls per observation
+  are not viable at scale.
+- **Latency.** Deterministic scoring is sub-millisecond; LLM calls are
+  hundreds of milliseconds.
+
+A frontier model can reason about risk qualitatively. It cannot replace a
+deterministic, audited, low-latency scoring path.
+
+## Decision
+
+We will extract `nous/internal/risk/` and `nous/internal/intervention/`
+into a new standalone repository: **`github.com/felixgeelhaar/decisionkit`**.
+
+The new repo is a small, single-purpose Go module:
+
+- `decisionkit/risk/` — copied verbatim from `nous/internal/risk/`, including
+  the existing test suite.
+- `decisionkit/intervention/` — copied verbatim from `nous/internal/intervention/`,
+  including tests.
+- `decisionkit/mnemos/` — new thin adapter mapping `mnemos.Event` into the
+  factor inputs the risk scorer expects, so consumers can call
+  `decisionkit.Score(events)` directly against a Mnemos query result.
+
+We do **not** carry over from Nous:
+
+- The LLM extractor (`internal/llm`) — replaced by agent tool calls.
+- Storage adapters (`internal/store`) — Mnemos owns event storage.
+- gRPC / HTTP transports — decisionkit is a library, not a service.
+- The commitment domain model — stays in the archived Nous repo for
+  reference; consumers using decisionkit construct their own input shapes.
+
+Initial release: `v0.1.0`. Pre-1.0 versioning until at least 90 days of
+consumer feedback or a second adopter beyond Obvia.
+
+## Consequences
+
+**Positive:**
+
+- Obvia gets a small, focused dependency with deterministic, audited
+  scoring. No coupling to Nous's service shell or any LLM provider.
+- Future programmatic systems (if they emerge) have a library to embed
+  without standing up a service.
+- The 90%+ test coverage from Nous comes along — no rewrite, no fidelity
+  loss.
+
+**Negative / risks:**
+
+- We introduce a new repo to maintain. Mitigation: small surface area (two
+  packages of pure functions); no roadmap beyond bug fixes.
+- decisionkit's API shape may need iteration based on Obvia's actual usage.
+  Mitigation: ship `v0.x` until proven; sealed types where the API
+  could evolve.
+
+## Migration path
+
+Nous consumers (currently only Olymp, which is also being archived):
+
+1. Replace import `github.com/felixgeelhaar/nous/internal/risk` with
+   `github.com/felixgeelhaar/decisionkit/risk`.
+2. Replace import `github.com/felixgeelhaar/nous/internal/intervention` with
+   `github.com/felixgeelhaar/decisionkit/intervention`.
+3. If the consumer was using Nous's storage or gRPC layer for risk inputs,
+   call the appropriate Mnemos query directly and feed results into
+   `decisionkit/mnemos.ToFactors(events)` before scoring.
+
+Since Olymp is archived, there are no live migrations required at the time
+of decisionkit creation. The migration path documented here is for any
+future consumer who picks Nous up from its archived state.
+
+## Alternatives Considered
+
+**1. Inline risk + intervention into Obvia directly.**
+Rejected. Obvia is the only programmatic consumer *today*, but a small
+shared library is cheap to publish and worth keeping reusable. The cost
+delta between "inline" and "small lib" is negligible; the optionality is
+real.
+
+**2. Migrate risk + intervention into Mnemos as `internal/decisions/`.**
+Rejected. Risk scoring is policy, not memory. Mnemos has been
+disciplined about not owning intent or decision logic. Folding decisions
+into Mnemos overloads the substrate and contaminates the "memory layer"
+positioning.
+
+**3. Use the Anthropic SDK / agent tool calls for risk scoring instead.**
+Rejected. Quantitative, deterministic, auditable, low-latency scoring is
+not a strength of LLMs. The risk scorer's factor breakdown is the audit
+trail; an LLM judgement is opaque to compliance review.
+
+## Related Work
+
+- [ADR 0003: Archive Olymp](0003-archive-olymp.md)
+- [ADR 0005: Archive Nous](0005-archive-nous.md)
+- [ADR 0006: Archive Praxis](0006-archive-praxis.md)

--- a/docs/adr/0005-archive-nous.md
+++ b/docs/adr/0005-archive-nous.md
@@ -1,0 +1,139 @@
+# ADR 0005: Archive Nous
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Deciders:** Felix Geelhaar
+- **Scope:** Cognitive stack repository topology. Depends on ADR 0004
+  (decisionkit) being in place first.
+
+## Context
+
+Nous was the "reasoning" primitive in the cognitive stack: a service that
+ingested events, extracted commitments via LLM, scored them for risk,
+decided interventions, and emitted decisions through gRPC/HTTP.
+
+A repository audit on 2026-05-31 produced three findings:
+
+1. **The only consumer of Nous is Olymp**, which is itself being archived
+   (ADR 0003). After Olymp goes away, Nous has zero callers.
+2. **The LLM extraction layer is replaceable by agent runtimes.** Frontier
+   models plus tool use handle commitment extraction with comparable or
+   better accuracy and no service to maintain.
+3. **The deterministic value (risk scoring + intervention policy) is
+   extractable into a small library**, which we are doing in ADR 0004
+   (decisionkit).
+
+Nous's gRPC/HTTP transport, multi-backend storage, LLM client abstraction,
+configuration, and adapter orchestration with circuit breakers all exist
+to support a service deployment. With no service deployment in our future,
+all of that ceases to earn its keep.
+
+## Decision
+
+We will archive the Nous repository after decisionkit (ADR 0004) ships.
+The repo stays publicly readable but is set to read-only on GitHub and
+tagged with its final release version. Its README is replaced with a
+redirect to decisionkit + mnemos, and a `DEPRECATED.md` is added at the
+repo root with the rationale and the recovery path.
+
+The following Nous components die with the repo (no extraction):
+
+- **LLM extraction pipeline** (`internal/llm/`, `internal/pipeline/`) —
+  replaced by agent tool calls. A modern agent can extract structured
+  commitments from text via a single `extract_commitments` tool definition.
+- **gRPC + HTTP transport** (`internal/transport/`) — services aren't the
+  right shape for what's left.
+- **Multi-backend storage** (`internal/store/`) — Mnemos owns event
+  storage; Nous's parallel store has no consumer.
+- **Adapter orchestration with circuit breakers** (`internal/adapters/`) —
+  pattern is useful; consumers can use `fortify` or write their own. Not
+  worth a library extraction.
+- **Commitment / Decision / Intervention domain types** (`internal/domain/`) —
+  consumers using decisionkit construct input shapes appropriate to their
+  context. The Nous-specific shapes assumed a service deployment.
+
+The risk and intervention engines are extracted in [ADR 0004](0004-extract-decisionkit.md)
+before this archive proceeds.
+
+## Consequences
+
+**Positive:**
+
+- The cognitive stack loses an LLM-heavy service that mostly wrapped
+  capabilities now available in agent runtimes.
+- Maintenance burden drops: no more Nous releases, no more provider
+  rotations (Anthropic / OpenAI / Gemini / Bedrock / Ollama).
+- The valuable parts (risk + intervention) survive in a much smaller,
+  more reusable shape (decisionkit).
+
+**Negative / risks:**
+
+- The MVP work that shipped Nous to "production ready" (SLOs, graceful
+  shutdown, observability, tracing) is sunk. Acceptable: the value of
+  that work was always the production-grade pattern, not the specific
+  binary, and the pattern carries forward to other services.
+- A future consumer wanting Nous's exact LLM extraction shape will need
+  to resurrect from the tag. Acceptable: the LLM layer is the easiest
+  part to rebuild against modern providers anyway.
+
+## Pre-archive verification
+
+Performed at the time of decisionkit creation:
+
+```
+grep -rln '"github.com/felixgeelhaar/nous' --include='*.go' \
+    --exclude-dir=nous --exclude-dir=olymp .
+→ <verify zero matches before archiving; Olymp is the known consumer
+   and is also archived>
+```
+
+If any sibling outside Olymp imports Nous, that consumer must be migrated
+or its dependency removed before this archive proceeds.
+
+## Migration path
+
+For the Nous gRPC/HTTP API consumers (Olymp): no migration needed; Olymp
+is also archived.
+
+For risk + intervention scoring: see [ADR 0004](0004-extract-decisionkit.md).
+Switch imports from `github.com/felixgeelhaar/nous/internal/{risk,intervention}`
+to `github.com/felixgeelhaar/decisionkit/{risk,intervention}`. The factor
+input shape is preserved; storage and transport are not part of the new
+library.
+
+For LLM-based commitment extraction: implement as an agent tool. A typical
+shape:
+
+```go
+// Tool definition for an agent
+type ExtractCommitmentsInput struct {
+    Text string `json:"text"`
+}
+type ExtractCommitmentsOutput struct {
+    Commitments []Commitment `json:"commitments"`
+}
+```
+
+The agent runtime (Claude Code, Codex, Hermes, ...) handles the LLM call;
+Mnemos stores the extracted commitments as claims.
+
+## Alternatives Considered
+
+**1. Keep Nous alive for the risk + intervention engines.**
+Rejected. The 95% of Nous that's transport / storage / LLM glue isn't
+worth maintaining to host two small packages. Extraction is cleaner.
+
+**2. Fold decisionkit into Mnemos as `internal/decisions/` instead of a
+separate repo.**
+Rejected. See ADR 0004; risk scoring is policy, not memory.
+
+**3. Migrate Nous's LLM extraction into a Mnemos pipeline.**
+Rejected. Mnemos already has a rule-based extractor with an LLM fallback;
+adding a second LLM-extraction layer with different prompts and providers
+would duplicate functionality. Agent runtimes are the right home.
+
+## Related Work
+
+- [ADR 0003: Archive Olymp](0003-archive-olymp.md)
+- [ADR 0004: Extract decisionkit](0004-extract-decisionkit.md)
+- [ADR 0006: Archive Praxis](0006-archive-praxis.md)

--- a/docs/adr/0006-archive-praxis.md
+++ b/docs/adr/0006-archive-praxis.md
@@ -1,0 +1,161 @@
+# ADR 0006: Archive Praxis
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Deciders:** Felix Geelhaar
+- **Scope:** Cognitive stack repository topology. Depends on Obvia inlining
+  Praxis's orchestration primitives before this archive proceeds.
+
+## Context
+
+Praxis was the "action" primitive in the cognitive stack: a service that
+executed structured actions against vendors (Slack, GitHub, Linear, HTTP,
+Calendar, Email), with safety primitives layered around the execution path:
+
+- Stable `Action.ID` + idempotency keeper — re-execution of the same ID
+  never double-effects, even across restarts.
+- Allow/deny policy engine with first-match rules.
+- Outbox-backed outcome emission to Mnemos with retry.
+- Audit trail with full lifecycle replay and redaction.
+- Out-of-process plugin host with Fulcio keyless signing for sandboxed
+  vendor handlers.
+- Capability registry with schema validation.
+- MCP server exposing actions to agent runtimes.
+
+A repository audit on 2026-05-31 produced three findings:
+
+1. **Vendor handlers are the wrong shape for agent-driven workflows.**
+   Agent runtimes (Claude Code, Codex, Hermes, Nomi, OpenClaw, NanoClaw)
+   connect to vendors through MCP servers and tool definitions. They do
+   not import Go vendor handler libraries. The six Praxis handlers
+   (Slack/GitHub/Linear/HTTP/Calendar/Email) are dead weight for the
+   agent path.
+2. **Obvia is the only programmatic (non-agent) consumer.** Obvia uses
+   Praxis's HTTP API for compliance-grade remediation: idempotency,
+   audit trail, policy gating, outcome feedback. None of that requires
+   a separate service — Obvia can inline what it needs.
+3. **The plugin host + Fulcio signing exists because Praxis is a
+   multi-tenant service.** With execution moving in-process into Obvia,
+   that complexity ceases to earn its keep.
+
+There is no `actionkit` library extraction in scope. Rationale: with
+only one programmatic consumer (Obvia) and agent runtimes not needing
+the primitives at all, a shared library has insufficient justification.
+Obvia inlines what it needs; vendor handlers die.
+
+## Decision
+
+We will archive the Praxis repository **immediately after the Obvia inline
+migration PR merges**. The repo stays publicly readable, is set to
+read-only on GitHub, and is tagged `v0.3.1-final`. README is replaced with
+a redirect explaining the new architecture, and `DEPRECATED.md` documents
+the rationale plus the recovery path.
+
+The following Praxis components die with the repo:
+
+- HTTP / gRPC API server and middleware.
+- Out-of-process plugin host with Fulcio signing.
+- Six vendor handlers (Slack, GitHub, Linear, HTTP, Calendar, Email) —
+  Obvia rewrites with direct SDK calls (`slack-go`, `go-github`, ...);
+  agents use MCP servers.
+- Capability registry as a service. (Capabilities for agents = tool
+  definitions in their runtime.)
+- Praxis MCP server. (Each agent runtime exposes its own MCP surface.)
+- The executor and handler-runner orchestration.
+
+The following primitives are **inlined into Obvia** (not extracted into
+a library):
+
+- Idempotency keeper from `praxis/internal/idempotency/` (~25 LOC).
+- Outbox-backed outcome emission from `praxis/internal/outcome/`, adapted
+  to talk to Mnemos directly. Event name renamed from
+  `praxis.action_completed` to `action.completed` to drop the praxis
+  namespace.
+- Audit trail from `praxis/internal/audit/` (or simplified to bolt
+  structured logs if Obvia's needs are lighter).
+- Policy engine from `praxis/internal/policy/` **only if Obvia actually
+  uses it** (verified by grep before inlining).
+
+This inlining ships as a single PR in the Obvia repo with no feature flag
+and no canary — Obvia is in dogfooding with no external users, so a
+straight cutover is acceptable.
+
+## Consequences
+
+**Positive:**
+
+- The cognitive stack loses an action service whose primary justification
+  was multi-tenancy, sandboxing, and vendor wrappers. None of those serve
+  the agent-driven future.
+- Obvia owns its own execution path with no remote-service hop, lower
+  latency, and a smaller failure surface.
+- Vendor SDKs are called directly where they're called — agents via MCP,
+  Obvia via Go SDK imports. No abstraction tax.
+
+**Negative / risks:**
+
+- The replay-from-audit invariant ("operators can derive state from audit
+  alone") becomes Obvia's responsibility to preserve. Mitigation: copy
+  the audit tests with the code; require parity before merging.
+- Praxis's out-of-process sandboxing for vendor handlers is lost. In a
+  multi-tenant service that mattered; in Obvia's single-tenant programmatic
+  loop it does not.
+- A future programmatic consumer that needs the same primitives will have
+  to either inline them itself or extract a library at that point.
+  Acceptable: speculative library extraction has been actively rejected
+  (see "Alternatives Considered").
+
+## Pre-archive verification
+
+Before tagging the final release:
+
+```
+grep -rln 'felixgeelhaar/praxis\|praxis://\|PRAXIS_' \
+    --exclude-dir=praxis --exclude-dir=obvia .
+→ <verify zero matches; Obvia is the known consumer and has just inlined>
+```
+
+If any sibling outside Obvia references Praxis (host config, env vars,
+direct Go import), that consumer must be migrated or its reference removed
+before this archive proceeds.
+
+## Migration path
+
+For Obvia: see the Obvia inline migration PR. Replace
+`obvia/internal/application/remediation/praxis.go` (HTTP client) with the
+inlined primitives plus direct vendor SDK calls. Delete
+`obvia/deploy/docker-compose/chaos/cmd/praxis-runtime/` stub.
+
+For any future consumer wanting Praxis's exact shape: resurrect the code
+from the `v0.3.1-final` tag. The full source (executor, idempotency,
+outbox, audit, policy, plugin host, handlers) is preserved at that tag.
+
+## Alternatives Considered
+
+**1. Extract an `actionkit` library** (idempotency + outbox + audit +
+policy + executor + Playbook executor + vendor handlers).
+Rejected. The single concrete consumer (Obvia) inlines orchestration
+primitives anyway; vendor handlers are the wrong shape for agent
+consumers (who use MCP); a library targeting a single consumer is not
+worth the maintenance overhead. See the planning conversation transcript
+for the full audit of this option.
+
+**2. Fold Praxis into Hermes** as `hermes/action`.
+Rejected. Mnemos must work with any agent runtime; making the action
+layer Hermes-specific contaminates the runtime-neutral architecture goal.
+
+**3. Keep Praxis alive as a standalone "safe execution sidecar".**
+Rejected. With one consumer and an agent path that doesn't need it, the
+sidecar is more operational complexity than it earns back.
+
+**4. Migrate Praxis's Playbook executor into Mnemos.**
+Not applicable. Mnemos defines `Playbook` as a data structure (synthesised
+from Lessons in Phase 6 / 7), but no executor was ever built. The type
+stays in Mnemos as an export-only artifact; the executor concern is
+shelved until a real consumer asks for it.
+
+## Related Work
+
+- [ADR 0003: Archive Olymp](0003-archive-olymp.md)
+- [ADR 0004: Extract decisionkit](0004-extract-decisionkit.md)
+- [ADR 0005: Archive Nous](0005-archive-nous.md)

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -474,3 +474,69 @@ Step 3 of the original observability bundle, scoped to its own task because it's
 Split from the original observability+rotation bundle. internal/auth/jwt.go currently signs HS256 without a `kid` (key id) header. The dual-key Verifier (NewVerifierWithPrevious) brute-tries the previous secret on every signature error — when an attacker forges a wrong-but-plausible token the verifier silently consults both secrets, masking real attacks in logs. Add: include `kid` (an opaque short id, e.g. first 8 hex chars of SHA-256(secret)) in the JWT header on issue; select verification key by `kid` in NewVerifierWithPrevious; record the chosen key in audit logs so anomalous combinations surface; rotate kid on each LoadOrCreateSecret cycle. Tests cover (a) issue→verify happy path with kid, (b) rotation across two kids, (c) fabricated unknown-kid is rejected. Out of scope here: full asymmetric signing — HS256 stays.
 
 ---
+
+## Archive olymp repo
+
+Tag olymp v0.1.5-final, replace README with redirect to mnemos + decisionkit, add DEPRECATED.md, set GitHub repo to archived. Zero Go consumers verified across siblings. Write ADR-001 in mnemos/docs/adr/001-archive-olymp.md citing the audit. Olymp's FSM loop, federation Peer, MCP tools, intent registry, and adapters all die with the repo (no extraction). Pre-archive grep across all business-felix-geelhaar/* go.mod files to confirm zero imports. Recoverable via tag.
+
+---
+
+## Extract decisionkit library from nous
+
+Create new repo github.com/felixgeelhaar/decisionkit by copying nous/internal/risk/ + nous/internal/intervention/ verbatim with tests. Strip storage adapters, gRPC, LLM glue. Add decisionkit/mnemos adapter converting mnemos.Event into factor inputs. Maintain Nous's 90%+ test coverage as release gate. Cut v0.1.0. Write ADR-002 in mnemos/docs/adr/002-extract-decisionkit.md. Justification: Obvia needs deterministic risk + intervention scoring for compliance/cost/latency reasons; cannot be cleanly replaced by LLM calls.
+
+---
+
+## Archive nous repo
+
+After decisionkit ships, tag nous final, replace README with redirect to decisionkit, add DEPRECATED.md, set GitHub repo to archived. Nous's gRPC/HTTP transports, LLM extractor, multi-backend storage, and commitment service die with the repo. Only Olymp depended on Nous, and Olymp is already archived. Write ADR-003 in mnemos/docs/adr/003-archive-nous.md.
+
+---
+
+## Mnemos root library package and mnemos.New entry point
+
+Add a root-level public library API so external consumers (Hermes, Nomi, OpenClaw, NanoClaw, Claude Code via MCP, agent runtimes) can do `import "github.com/felixgeelhaar/mnemos"` and call `mnemos.New(opts...)`. Today mnemos is CLI/MCP/HTTP service only — no in-process library face exists. Create mnemos/memory.go with Memory interface (Remember, Recall, RememberEvent, Timeline), mnemos/new.go wiring internal/store + internal/pipeline + internal/query through the public surface, and mnemos/memory_impl.go binding methods. Touch nothing under internal/. Mark v0.x until 90 days of consumer feedback.
+
+---
+
+## Framework-neutral provider interfaces (TextGenerator and Embedder)
+
+Create new public mnemos/providers/ subpackage exporting TextGenerator and Embedder interfaces as thin wrappers around existing internal/llm.Client + internal/embedding.Client. Goal: agent runtimes (Hermes, Nomi, OpenClaw, NanoClaw, Claude Code, Codex, future frameworks) implement these as adapters around their own model clients. No Hermes-specific types in mnemos core. Verify no leaky provider details. Files: mnemos/providers/text.go, mnemos/providers/embedder.go.
+
+---
+
+## Three-mode option builders (Passive, SharedProvider, Enhanced)
+
+Implement mnemos/options.go with WithPassiveMode(), WithSharedProvider(tg, emb), WithEnhancedMode(cfg), WithChronos(c), WithStorage(dsn). Passive mode: no LLM, rule-based extraction + token-overlap query (zero env vars works). Shared provider: consumes external TextGenerator/Embedder from agent runtime. Enhanced: own LLM/embedding config. Passive must work out of the box — `mnemos.New()` with no args returns a working Memory. Sealed Option type prevents external impls.
+
+---
+
+## Chronos bundling — embedded by default inside mnemos.New
+
+Import github.com/felixgeelhaar/chronos as Go dependency. mnemos.New() boots in-process Chronos by default (no separate server). WithChronos(c) lets advanced users supply their own instance. Storage stays separate: chronos.db adjacent to mnemos.db at XDG path (~/.local/share/mnemos/chronos.db) due to different mutation semantics (Chronos signals transient, Mnemos events immutable). Adapter at internal/temporal/chronos_adapter.go implements chronos.Source, maps mnemos.Event ↔ chronos.EntityState and chronos.Signal → mnemos.Claim. Chronos standalone (chronos.New()) remains unchanged for advanced users (incident timelines, audit trails, replay).
+
+---
+
+## Temporal MCP tools (remember_event, timeline_query, recall_at_time)
+
+Register three new MCP tools in cmd/mnemos/mcp.go: remember_event (ingest single event into Chronos), timeline_query (range queries by run_id/scope/window), recall_at_time (claims valid at an instant + evidence chain). Add CLI subcommand mnemos timeline at cmd/mnemos/timeline.go. Auto-synthesize claims from Chronos signals — when a Signal fires, adapter creates a corresponding Claim with signal.Confidence linked back via evidence. Conservative detector thresholds + aggregation windows; off by default, opt-in via WithChronosDetectors.
+
+---
+
+## Refactor cmd/mnemos to route through new library
+
+Refactor cmd/mnemos/mcp.go to use mnemos.New() instead of raw repository wiring. All 25 existing MCP tools must continue to pass (no behavior change, routing only). Also refactor cmd/mnemos/process.go, query.go, ingest.go to use library where reasonable while keeping CLI flag parsing in cmd. Public docs at mnemos/docs/library.md with 3-mode examples + Go playground-ready snippets. Godoc examples in mnemos/example_test.go (Example_passive, Example_sharedProvider, Example_enhanced, Example_withChronos). Integration tests in mnemos/memory_test.go covering all 3 modes end-to-end + zero-config bootstrap test.
+
+---
+
+## Obvia inline migration off Praxis
+
+Replace obvia/internal/application/remediation/praxis.go (HTTP client) with inline orchestration. Copy idempotency keeper (~25 LOC) from praxis/internal/idempotency/, outbox emitter from praxis/internal/outcome/ (adapt to talk to mnemos directly), audit trail from praxis/internal/audit/, policy engine from praxis/internal/policy/ only if Obvia uses it (verify by grep). Vendor calls use direct SDKs (slack-go, go-github). Delete obvia/deploy/docker-compose/chaos/cmd/praxis-runtime/ stub. Update Obvia integration tests to exercise inline backend. Single PR, straight cutover — no feature flag because Obvia is dogfooding only with no external users.
+
+---
+
+## Archive praxis repo
+
+Immediately after Obvia inline PR merges, tag praxis v0.3.1-final, replace README with redirect to mnemos + actionkit-not-extracted note (explain Obvia inlined the orchestration primitives, vendor handlers belong to agents via MCP), add DEPRECATED.md, set GitHub repo to archived. Praxis's HTTP/gRPC API, out-of-process plugin host + Fulcio signing, 6 vendor handlers (Slack/GitHub/Linear/HTTP/Calendar/Email), capability registry, MCP server all die with the repo. Pre-archive grep all siblings for praxis host config to verify zero forgotten consumers beyond Obvia. Write ADR-004 in mnemos/docs/adr/004-archive-praxis.md.
+
+---


### PR DESCRIPTION
## Summary

Four ADRs documenting the cognitive-stack collapse from five primitives
(mnemos / chronos / nous / praxis / olymp) to three (mnemos / chronos /
agent runtimes). Memory + timeline stay; reasoning + action move into
agent runtimes (Claude Code, Codex, Hermes, Nomi, OpenClaw, NanoClaw, ...).

- **0003** archive olymp — zero Go importers; FSM patterns preserved at v0.1.5-final tag
- **0004** extract decisionkit — risk + intervention engines shipped as standalone lib
- **0005** archive nous — only consumer was olymp; deterministic value moved to decisionkit
- **0006** archive praxis — vendor handlers wrong shape for agents (use MCP); Obvia inlines orchestration

## Status of related work

- Olymp: **already archived** (https://github.com/felixgeelhaar/olymp)
- decisionkit: **shipped v0.1.0** (https://github.com/felixgeelhaar/decisionkit)
- Nous: **already archived** (https://github.com/felixgeelhaar/nous)
- Praxis: archive deferred until Obvia inlines primitives (separate PR)

## What's next

- Mnemos library refactor (workstream 2): root \`mnemos.New(opts...)\` entry point, framework-neutral \`TextGenerator\` / \`Embedder\` interfaces, 3-mode option builders (Passive / SharedProvider / Enhanced)
- Chronos bundling (workstream 3): \`mnemos.New()\` boots embedded Chronos by default; \`WithChronos(c)\` override; new temporal MCP tools

Each ships as its own PR.

## Test plan

- [x] ADRs render correctly on GitHub
- [x] Roady spec.yaml + backlog.md updated with the 10 new features
- [ ] Linked external archives (olymp, nous, decisionkit) accessible from links in ADRs