### PR TITLE
docs: cognitive-stack architecture sweep + v0.17.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,77 @@ Releases are tagged and published via GoReleaser; this file is the human-readabl
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-05-31
+
+Cognitive-stack simplification + embeddable library release. Mnemos
+becomes a first-class in-process Go library while keeping the CLI /
+MCP / HTTP surfaces unchanged. Chronos is bundled by default so
+temporal memory works out of the box. Four ADRs land that close the
+loop on retiring the dedicated reasoning / action / orchestration
+repos (nous / praxis / olymp) in favour of agent runtimes plus a
+small `decisionkit` library.
+
+### Added
+- **Root `mnemos` package** — `mnemos.New(opts...)` returns a
+  `Memory` interface with `Remember(ctx, Item)`, `Recall(ctx, Query)`,
+  `RememberEvent(ctx, Event)`, `Timeline(ctx, TimelineQuery)`, and
+  `Close()`. Additive: every existing CLI / MCP / HTTP surface is
+  unaffected. See [`docs/library.md`](docs/library.md).
+- **`mnemos/providers/` subpackage** — framework-neutral
+  `TextGenerator` and `Embedder` interfaces. Agent runtimes (Claude
+  Code, Codex, Hermes, Nomi, OpenClaw, NanoClaw, ...) implement these
+  as thin adapters around their own provider clients. Internal
+  `llm.Client` / `embedding.Client` are wrapped behind the public
+  surface.
+- **Three operating modes via Option builders** —
+  `WithPassiveMode()` (no LLM, rule-based extraction + token-overlap
+  ranking, zero env vars), `WithSharedProvider(tg, embedder)` (agent
+  runtime supplies the model), `WithEnhancedMode(cfg)` (dedicated
+  provider config).
+- **Chronos bundled by default** — `mnemos.New()` boots an in-process
+  Chronos engine (memory storage) so `RememberEvent` + `Timeline`
+  work out of the box. Power users supply their own configured
+  engine via `WithChronos(*embed.Engine)` for durable storage / custom
+  detectors. Requires `github.com/felixgeelhaar/chronos v0.6.0+`.
+- **Temporal MCP tools** — `remember_event`, `timeline_query`, and
+  `recall_at_time` (`query.AnswerOptions.AsOf`) join the existing
+  MCP surface; documented in the API parity matrix as MCP-only.
+- **Storage option** — `WithStorage(dsn)` overrides DSN resolution
+  for callers that don't want the default `MNEMOS_DB_URL > project
+  .mnemos > XDG default` precedence.
+- **Actor option** — `WithActor(userID)` overrides the actor stamp
+  on writes (default reads `MNEMOS_USER_ID` env, falls back to
+  `domain.SystemUser`).
+- **Godoc examples** — `Example_passive`, `Example_sharedProvider`,
+  `Example_enhanced`, `Example_withChronos` in `example_test.go`.
+
+### Documentation
+- **ADR 0003 — Archive Olymp** (zero Go importers; orchestration patterns
+  preserved at the `v0.1.5-final` tag).
+- **ADR 0004 — Extract decisionkit** (risk + intervention engines lifted
+  from `nous/internal/` into a standalone
+  [decisionkit](https://github.com/felixgeelhaar/decisionkit) module at
+  v0.1.0; Obvia and future programmatic consumers depend on it directly).
+- **ADR 0005 — Archive Nous** (only consumer was Olymp; LLM extraction
+  moves to agent runtimes; risk + intervention survive in decisionkit).
+- **ADR 0006 — Archive Praxis** (vendor handlers are the wrong shape for
+  agent-driven workflows; Obvia inlines orchestration primitives;
+  agents reach vendors via MCP).
+- **`docs/library.md`** — three-mode walkthrough with copy-pasteable
+  examples + Chronos bundling notes + storage backend matrix.
+
+### Changed
+- **README** — added an in-process Go library section above the HTTP
+  client section; refreshed the Playbook description (no longer
+  references Praxis as the executor since Praxis is archived).
+- **CLAUDE.md** — same Playbook refresh; Playbook is now described as
+  an "agent-ready response" consumers run through whatever execution
+  layer they own.
+
+### Removed
+- Nothing user-visible. The library is fully additive over v0.16.x;
+  CLI / MCP / HTTP surfaces are unchanged.
+
 ## [0.16.0] — 2026-05-24
 
 Agent-memory release. Eleven issues land that turn mnemos from a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ All implementations are behind these interfaces, enabling clean testing and prov
 - **Outcome** — observed result of an Action (action_id, result, metrics map, source push|pull:*)
 - **Lesson** — synthesised operational truth (statement, scope, evidence []ActionID, confidence, trigger, kind, source synthesize|human)
 - **Decision** — agent decision audit record (statement, plan, reasoning, risk_level, beliefs []ClaimID, alternatives, outcome_id)
-- **Playbook** — Praxis-ready response (trigger, scope, steps []PlaybookStep, derived_from_lessons, confidence)
+- **Playbook** — Agent-ready response (trigger, scope, steps []PlaybookStep, derived_from_lessons, confidence). Consumers run them through whatever execution layer they own.
 - **Scope** — multi-tenant filter primitive: {Service, Env, Team} (LessonScope is an alias kept for back-compat)
 - **Answer** — query result bundling claims, contradictions, timeline, hop distances, claim provenance, and `StaleClaimIDs`
 

--- a/README.md
+++ b/README.md
@@ -289,9 +289,43 @@ Full HTTP schema: [`api/openapi.yaml`](api/openapi.yaml).
 
 ### Integrating Mnemos in your app
 
-The HTTP API at `mnemos serve` is the integration surface. Three flavors:
+The HTTP API at `mnemos serve` is one integration surface; for Go apps you
+can also embed Mnemos in-process via the root package. Pick whichever
+matches your runtime.
 
-**Go (typed client)** — `import "github.com/felixgeelhaar/mnemos/client"`:
+**Go (in-process library, v0.17+)** — `import "github.com/felixgeelhaar/mnemos"`:
+
+```go
+import (
+    "github.com/felixgeelhaar/mnemos"
+    _ "github.com/felixgeelhaar/mnemos/internal/store/sqlite"
+)
+
+mem, err := mnemos.New() // passive mode, XDG storage, bundled Chronos
+if err != nil { panic(err) }
+defer mem.Close()
+
+_ = mem.Remember(ctx, mnemos.Item{
+    Type:    "decision",
+    Content: "Adopted Postgres for the new service.",
+})
+
+results, _ := mem.Recall(ctx, mnemos.Query{Text: "Postgres decision"})
+```
+
+Three modes: `WithPassiveMode()` (no LLM), `WithSharedProvider(tg, emb)`
+(agent runtime supplies the model), `WithEnhancedMode(cfg)` (dedicated
+provider). Chronos is bundled in-process by default; supply your own with
+`WithChronos(eng)`. See [`docs/library.md`](docs/library.md) for full
+3-mode walkthroughs + godoc examples.
+
+The HTTP API and MCP transport remain available for non-Go consumers; both
+route through the same internals.
+
+**Go (HTTP client)** — `import "github.com/felixgeelhaar/mnemos/client"`:
+
+When you do want HTTP from Go (different process, or non-Go consumer over
+HTTP that needs a typed client):
 
 ```go
 c := client.New("http://localhost:7777",
@@ -598,7 +632,7 @@ Mnemos has shipped a self-learning loop on top of the evidence layer:
 - **Causal edges** — `causes`, `caused_by`, `action_of`, `outcome_of`, `validates`, `refutes`, `derived_from` extend the relationship graph beyond logical agreement. `relate.DetectCausal` infers these from event-time + shared-entity signals; the optional `relate.DetectCausalLLM` augments borderline pairs via LLM disambiguation.
 - **Action + Outcome recording** — `mnemos action record` / `mnemos outcome record` capture operational changes and their observed metrics. The Prometheus pull adapter (`internal/adapters/outcomes/prometheus.go`) scrapes metrics and produces Outcomes automatically.
 - **Lessons synthesis** — `mnemos synthesize` clusters action→outcome chains into validated Lessons (confidence = corroboration × consistency × recency).
-- **Playbooks** — `mnemos playbook synthesize` derives steps-only operational intelligence from Lesson clusters; Praxis (or any execution layer) consumes them.
+- **Playbooks** — `mnemos playbook synthesize` derives steps-only operational intelligence from Lesson clusters. Consumers run them through whatever execution layer they own (an agent runtime, an in-process executor, a programmatic system).
 - **Decisions** — `mnemos decision record` audits agent reasoning with belief claims, alternatives, and risk level; outcomes attach later via `decision attach-outcome`.
 - **Temporal hardening** — per-claim `last_verified`, `verify_count`, `half_life_days`. `mnemos verify` re-confirms a claim; `Answer.StaleClaimIDs` surfaces decay below the trust floor.
 - **Multi-tenant scope** — `Scope{Service, Env, Team}` on Claims, Lessons, Decisions, Playbooks; `mnemos query --service X --env prod` filters the answer.


### PR DESCRIPTION
## Summary

Documentation follow-up after the cognitive-stack simplification + library API + Chronos bundling + temporal MCP tools landed (#48).

- **README** — adds an in-process Go library section (\`mnemos.New\` + 3 modes + \`WithChronos\`) above the existing HTTP client section so Go consumers know the library exists. Refreshes the Playbook description to drop the Praxis reference (Praxis was archived 2026-05-31).
- **CLAUDE.md** — same Playbook refresh; Playbook is described as "agent-ready" now instead of "Praxis-ready".
- **CHANGELOG** — \`v0.17.0\` entry covering the library API, providers package, 3 option-builder modes, Chronos bundling, the 3 new temporal MCP tools, and the ADR 0003-0006 batch.

## Test plan

- [x] \`make check\` green