### PR TITLE
feat(library): RememberClaim — third input mode (agent-supplied claims)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Releases are tagged and published via GoReleaser; this file is the human-readabl
 
 ## [Unreleased]
 
+### Added
+- **`Memory.RememberClaim(ClaimItem)`** — third input mode for the
+  library API. Agent runtimes that have already derived structured
+  claims (with their own model or from parsed structured data) can
+  hand them to Mnemos verbatim, bypassing the extraction pipeline.
+  Companions to the existing rule-based and LLM-driven text-ingestion
+  paths. See [`docs/library.md`](docs/library.md) "Three input modes"
+  + `ExampleMemory_rememberClaim` in `example_test.go`.
+
 ## [0.17.0] — 2026-05-31
 
 Cognitive-stack simplification + embeddable library release. Mnemos

--- a/docs/library.md
+++ b/docs/library.md
@@ -122,6 +122,63 @@ mem, _ := mnemos.New(
 Useful when you want background enrichment on a separate (cheaper /
 specialised) model, or to separate billing.
 
+## Three input modes (passive / LLM-driven / agent-supplied)
+
+Mnemos has three orthogonal paths for getting knowledge into the store.
+They cover different consumer needs and can be mixed freely.
+
+### Mode 1 — passive text ingestion (no LLM)
+
+```go
+mem.Remember(ctx, mnemos.Item{
+    Type:    "fact",
+    Content: "The deployment succeeded in production.",
+})
+```
+
+Mnemos runs its built-in rule-based extractor; one or more `Claim`s are
+derived from the text and linked to a synthetic source event. No model
+call, no per-call cost. Best for tests, smoke demos, or environments
+where you don't want any external dependency.
+
+### Mode 2 — LLM-driven text ingestion (shared or enhanced)
+
+Same `Remember` call as Mode 1; the difference is the construction
+option:
+
+```go
+mem, _ := mnemos.New(mnemos.WithSharedProvider(myTextGen, myEmbedder))
+mem.Remember(ctx, mnemos.Item{
+    Type:    "fact",
+    Content: "Long document with many implicit assertions ...",
+})
+```
+
+The configured `TextGenerator` runs structured extraction; claims are
+typed (fact / hypothesis / decision) with calibrated confidence. Best
+for ingesting prose, meeting notes, design docs.
+
+### Mode 3 — agent-supplied claims (no extraction)
+
+When the agent runtime has *already* derived structured assertions
+(with its own model, from parsed structured data, from a function-call
+result), it can hand them to Mnemos directly:
+
+```go
+claimID, _ := mem.RememberClaim(ctx, mnemos.ClaimItem{
+    Text:       "User prefers Go for backend work.",
+    Type:       "fact",
+    Confidence: 0.95,
+    EventIDs:   []string{"evt-source-1"}, // link to events you persisted
+    RunID:      "session-A",
+})
+```
+
+No extraction runs; Mnemos persists the claim verbatim. Recommended
+pattern: call `RememberEvent` first to anchor the claim, then
+`RememberClaim` with the event id in `EventIDs`. Claims without
+evidence skip the corroboration + freshness ranking factors.
+
 ## Temporal memory: events + Chronos
 
 Mnemos bundles [Chronos](https://github.com/felixgeelhaar/chronos) as an

--- a/example_test.go
+++ b/example_test.go
@@ -81,6 +81,42 @@ func ExampleNew_sharedProvider() {
 	// Output:
 }
 
+// ExampleMemory_rememberClaim shows the third input mode: an agent
+// runtime hands a pre-built claim to Mnemos directly, bypassing the
+// extraction pipeline. Useful when the agent has already derived a
+// structured assertion with its own model or from parsed structured
+// data.
+func ExampleMemory_rememberClaim() {
+	mem, _ := mnemos.New(
+		mnemos.WithStorage("memory://?namespace=example_remember_claim"),
+		mnemos.WithPassiveMode(),
+	)
+	defer func() { _ = mem.Close() }()
+
+	ctx := context.Background()
+
+	// Step 1: anchor the claim to a source event the agent observed.
+	_ = mem.RememberEvent(ctx, mnemos.Event{
+		ID:      "evt-obs-1",
+		At:      time.Now(),
+		Type:    "observation",
+		Content: "User said: I prefer Go for backend.",
+		RunID:   "session-A",
+	})
+
+	// Step 2: the agent has already extracted a structured claim from
+	// the event using its own reasoning. Hand it to Mnemos verbatim.
+	claimID, _ := mem.RememberClaim(ctx, mnemos.ClaimItem{
+		Text:       "User prefers Go for backend work.",
+		Type:       "fact",
+		Confidence: 0.95,
+		EventIDs:   []string{"evt-obs-1"},
+		RunID:      "session-A",
+	})
+	_ = claimID
+	// Output:
+}
+
 // ExampleNew_withChronos shows supplying a custom Chronos engine for
 // durable temporal storage. The default mnemos.New() boots an
 // in-memory Chronos automatically; pass WithChronos when you want

--- a/memory.go
+++ b/memory.go
@@ -51,6 +51,60 @@ import (
 	"time"
 )
 
+// ClaimItem is a pre-built claim an agent runtime can hand to Mnemos
+// directly, bypassing the extraction pipeline. Use this when the
+// agent has already derived structured assertions (with its own model,
+// from parsed structured data, or through any other path) and wants
+// Mnemos to persist them as-is.
+//
+// This is the third of Mnemos's three input modes:
+//
+//  1. [Item] + [Memory.Remember] → rule-based extraction (passive mode)
+//     or LLM-driven extraction (shared / enhanced mode).
+//  2. Same Item path with WithSharedProvider / WithEnhancedMode →
+//     extraction uses the configured language model.
+//  3. ClaimItem + [Memory.RememberClaim] → no extraction at all;
+//     Mnemos stores the supplied claim verbatim and (optionally) links
+//     it to source events the caller has already persisted via
+//     [Memory.RememberEvent].
+type ClaimItem struct {
+	// Text is the claim content. Required.
+	Text string
+
+	// Type classifies the claim. Mnemos recognises "fact",
+	// "hypothesis", "decision", and "test_result" natively. Defaults
+	// to "fact" when empty.
+	Type string
+
+	// Confidence is the agent's confidence in [0, 1]. Defaults to 1.0
+	// when zero (the agent is asserting the claim with full
+	// confidence). Mnemos will recompute the trust score from this
+	// confidence × corroboration × freshness at query time.
+	Confidence float64
+
+	// EventIDs links the claim back to source events. Optional but
+	// strongly recommended: claims without evidence cannot be ranked
+	// by corroboration and skip the freshness factor. Each id must
+	// already exist in the event store (use [Memory.RememberEvent] to
+	// add them first).
+	EventIDs []string
+
+	// ValidFrom is when the claim's content first became true. Zero
+	// value means "valid since before the system started tracking";
+	// for fresh claims, set this to time.Now() or the time the agent
+	// observed the fact.
+	ValidFrom time.Time
+
+	// ValidUntil is when the claim stopped being true (a successor
+	// claim took its place). Zero value means "currently valid".
+	ValidUntil time.Time
+
+	// RunID groups related claims together for scoped recall.
+	// Optional; matches the RunID used on the linked events when
+	// present.
+	RunID string
+}
+
 // Item is a single piece of knowledge to remember. Type and Content are
 // the only required fields; everything else is optional.
 type Item struct {
@@ -195,6 +249,18 @@ type Memory interface {
 	// any derived claims with full evidence links back to the source
 	// event.
 	Remember(ctx context.Context, item Item) error
+
+	// RememberClaim stores a pre-built claim directly, without running
+	// extraction. Use this when an agent runtime has already derived a
+	// structured assertion (with its own model, parsed structured data,
+	// etc.) and wants Mnemos to persist it verbatim. Linked source
+	// events (referenced via [ClaimItem.EventIDs]) must already exist
+	// in the event store — add them with [Memory.RememberEvent] first
+	// when they're new.
+	//
+	// Returns the generated claim ID so the caller can reference the
+	// claim in future relationship edges or evidence links.
+	RememberClaim(ctx context.Context, claim ClaimItem) (string, error)
 
 	// Recall answers a query against the stored knowledge. The result
 	// is ranked by trust score (or token overlap in passive mode when

--- a/memory_impl.go
+++ b/memory_impl.go
@@ -98,6 +98,50 @@ func (m *memory) Remember(ctx context.Context, item Item) error {
 	return nil
 }
 
+// RememberClaim implements [Memory.RememberClaim].
+func (m *memory) RememberClaim(ctx context.Context, item ClaimItem) (string, error) {
+	if strings.TrimSpace(item.Text) == "" {
+		return "", errors.New("mnemos: RememberClaim: Text is required")
+	}
+
+	claimType := domain.ClaimType(item.Type)
+	if claimType == "" {
+		claimType = domain.ClaimTypeFact
+	}
+	confidence := item.Confidence
+	if confidence == 0 {
+		confidence = 1.0
+	}
+
+	id := fmt.Sprintf("cl_%d", time.Now().UnixNano())
+	claim := domain.Claim{
+		ID:         id,
+		Text:       item.Text,
+		Type:       claimType,
+		Confidence: confidence,
+		Status:     domain.ClaimStatusActive,
+		CreatedAt:  time.Now().UTC(),
+		CreatedBy:  m.actorID,
+		ValidFrom:  item.ValidFrom,
+		ValidTo:    item.ValidUntil,
+	}
+
+	if err := m.conn.Claims.Upsert(ctx, []domain.Claim{claim}); err != nil {
+		return "", fmt.Errorf("mnemos: upsert claim: %w", err)
+	}
+
+	if len(item.EventIDs) > 0 {
+		links := make([]domain.ClaimEvidence, len(item.EventIDs))
+		for i, eid := range item.EventIDs {
+			links[i] = domain.ClaimEvidence{ClaimID: id, EventID: eid}
+		}
+		if err := m.conn.Claims.UpsertEvidence(ctx, links); err != nil {
+			return "", fmt.Errorf("mnemos: link evidence: %w", err)
+		}
+	}
+	return id, nil
+}
+
 // Recall implements [Memory.Recall].
 func (m *memory) Recall(ctx context.Context, q Query) ([]Result, error) {
 	if strings.TrimSpace(q.Text) == "" {

--- a/memory_test.go
+++ b/memory_test.go
@@ -54,6 +54,151 @@ func TestNew_PassiveMode_ZeroConfig(t *testing.T) {
 	}
 }
 
+// TestRememberClaim_BypassesExtraction verifies the third input mode:
+// an agent runtime hands a pre-built claim to Mnemos and Mnemos
+// persists it verbatim, without running text extraction. This is the
+// path agent runtimes use when they've already derived structured
+// claims (own model, parsed data, etc.).
+func TestRememberClaim_BypassesExtraction(t *testing.T) {
+	t.Parallel()
+	clearMnemosEnv(t)
+
+	mem, err := mnemos.New(
+		mnemos.WithStorage("memory://?namespace=mnemos_remember_claim_test"),
+		mnemos.WithPassiveMode(),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = mem.Close() }()
+
+	ctx := context.Background()
+
+	// First seed a source event the claim will reference. Skipping
+	// this is allowed (EventIDs is optional) but exercises the
+	// evidence-link path.
+	eventAt := time.Date(2026, 5, 31, 10, 0, 0, 0, time.UTC)
+	if err := mem.RememberEvent(ctx, mnemos.Event{
+		ID:      "evt-source-1",
+		At:      eventAt,
+		Type:    "observation",
+		Content: "User said they prefer Go for backend work.",
+		RunID:   "claim-test",
+	}); err != nil {
+		t.Fatalf("RememberEvent: %v", err)
+	}
+
+	claimID, err := mem.RememberClaim(ctx, mnemos.ClaimItem{
+		Text:       "User prefers Go for backend work.",
+		Type:       "fact",
+		Confidence: 0.95,
+		EventIDs:   []string{"evt-source-1"},
+		ValidFrom:  eventAt,
+		RunID:      "claim-test",
+	})
+	if err != nil {
+		t.Fatalf("RememberClaim: %v", err)
+	}
+	if claimID == "" {
+		t.Fatal("RememberClaim returned empty ID")
+	}
+
+	// Now query — the claim should surface even though no extraction
+	// pipeline ran (the rule-based extractor would not have produced
+	// this exact text from the event content).
+	results, err := mem.Recall(ctx, mnemos.Query{Text: "user prefers Go backend"})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("Recall returned 0 results after RememberClaim")
+	}
+	if results[0].ClaimID != claimID {
+		t.Errorf("top result ID = %q, want %q", results[0].ClaimID, claimID)
+	}
+	if results[0].Confidence != 0.95 {
+		t.Errorf("Confidence = %v, want 0.95", results[0].Confidence)
+	}
+}
+
+// TestRememberClaim_DefaultsTypeAndConfidence verifies the empty-field
+// defaults: Type defaults to "fact", Confidence defaults to 1.0.
+func TestRememberClaim_DefaultsTypeAndConfidence(t *testing.T) {
+	t.Parallel()
+	clearMnemosEnv(t)
+
+	mem, err := mnemos.New(
+		mnemos.WithStorage("memory://?namespace=mnemos_remember_claim_defaults_test"),
+		mnemos.WithPassiveMode(),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = mem.Close() }()
+
+	// Anchor the claim to an event so the recall path can find it
+	// (claims without evidence don't surface through the standard
+	// retrieval pipeline).
+	ctx := context.Background()
+	if err := mem.RememberEvent(ctx, mnemos.Event{
+		ID:      "evt-defaults-1",
+		At:      time.Now(),
+		Type:    "observation",
+		Content: "default shape note",
+		RunID:   "defaults",
+	}); err != nil {
+		t.Fatalf("RememberEvent: %v", err)
+	}
+
+	id, err := mem.RememberClaim(ctx, mnemos.ClaimItem{
+		Text:     "default shape claim with no type or confidence supplied",
+		EventIDs: []string{"evt-defaults-1"},
+		RunID:    "defaults",
+	})
+	if err != nil {
+		t.Fatalf("RememberClaim: %v", err)
+	}
+
+	results, err := mem.Recall(ctx, mnemos.Query{Text: "default shape claim"})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("Recall returned 0 results")
+	}
+	if results[0].ClaimID != id {
+		t.Errorf("ClaimID = %q, want %q", results[0].ClaimID, id)
+	}
+	if results[0].Type != "fact" {
+		t.Errorf("Type = %q, want %q (default)", results[0].Type, "fact")
+	}
+	if results[0].Confidence != 1.0 {
+		t.Errorf("Confidence = %v, want 1.0 (default)", results[0].Confidence)
+	}
+}
+
+// TestRememberClaim_RejectsEmptyText verifies validation.
+func TestRememberClaim_RejectsEmptyText(t *testing.T) {
+	t.Parallel()
+	clearMnemosEnv(t)
+
+	mem, err := mnemos.New(
+		mnemos.WithStorage("memory://?namespace=mnemos_remember_claim_validation_test"),
+		mnemos.WithPassiveMode(),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = mem.Close() }()
+
+	_, err = mem.RememberClaim(context.Background(), mnemos.ClaimItem{
+		Text: "  ", // whitespace-only
+	})
+	if err == nil {
+		t.Fatal("RememberClaim with empty Text returned nil error; expected validation error")
+	}
+}
+
 // TestRememberEvent_Timeline verifies temporal recall works without
 // Chronos wired up (raw event-store path). Chronos integration lands in
 // task 12; this test pins the storage-side contract.


### PR DESCRIPTION
## Summary

Original brief specified three input modes for the Mnemos library; v0.17.0 shipped two (passive text + LLM-driven text). This PR adds the third: agent runtimes that already have structured claims (own model, parsed structured data, function-call results) hand them to Mnemos directly via \`RememberClaim\`, bypassing the extraction pipeline.

## API additions

\`\`\`go
type ClaimItem struct {
    Text       string         // required
    Type       string         // defaults to "fact"
    Confidence float64        // defaults to 1.0 when zero
    EventIDs   []string       // optional evidence links
    ValidFrom  time.Time      // optional bitemporal start
    ValidUntil time.Time      // optional bitemporal end (zero = still valid)
    RunID      string         // optional scope
}

type Memory interface {
    ...
    RememberClaim(ctx context.Context, claim ClaimItem) (claimID string, err error)
}
\`\`\`

Implementation persists via the existing \`ClaimRepository.Upsert\` + \`UpsertEvidence\` ports; respects the actor stamp; applies the documented defaults.

## Three input modes (now all exposed via the library)

| Mode | Path | Use when |
|---|---|---|
| 1. Passive | \`Remember(Item)\` + \`WithPassiveMode()\` | No LLM; rule-based extraction; zero per-call cost |
| 2. LLM-driven | \`Remember(Item)\` + \`WithSharedProvider\` or \`WithEnhancedMode\` | Prose / docs; LLM does structured extraction |
| 3. Agent-supplied | \`RememberClaim(ClaimItem)\` | Agent already has structured claims; skip extraction |

## Test plan

- [x] \`make check\` green
- [x] \`TestRememberClaim_BypassesExtraction\` — full roundtrip with event anchor
- [x] \`TestRememberClaim_DefaultsTypeAndConfidence\` — empty-field defaults applied
- [x] \`TestRememberClaim_RejectsEmptyText\` — validation
- [x] \`ExampleMemory_rememberClaim\` godoc example runs green
- [x] \`docs/library.md\` "Three input modes" walkthrough updated