### PR TITLE
feat(cli): mnemos claim record — third input mode on the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Releases are tagged and published via GoReleaser; this file is the human-readabl
   Companions to the existing rule-based and LLM-driven text-ingestion
   paths. See [`docs/library.md`](docs/library.md) "Three input modes"
   + `ExampleMemory_rememberClaim` in `example_test.go`.
+- **`mnemos claim record`** CLI subcommand — exposes the same
+  agent-supplied claim path from the command line. Flags:
+  `--text`, `--type`, `--confidence`, `--run-id`, `--event-ids`
+  (comma-separated), `--valid-from`, `--valid-until`. Routes through
+  the library API (`library_bridge.newLibraryMemory`).
+
+### Surface coverage for the third input mode
+- Library: `Memory.RememberClaim(ClaimItem)`
+- CLI: `mnemos claim record --text ... [flags]`
+- MCP: pre-existing `remember` tool (creates event + claim + evidence atomically)
 
 ## [0.17.0] — 2026-05-31
 

--- a/cmd/mnemos/claims.go
+++ b/cmd/mnemos/claims.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/felixgeelhaar/mnemos"
+)
+
+// handleClaim routes `mnemos claim <subcommand> ...`.
+func handleClaim(args []string, _ Flags) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: mnemos claim record --text <text> [flags]")
+		os.Exit(int(ExitUsage))
+	}
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "record":
+		handleClaimRecord(rest)
+	default:
+		fmt.Fprintf(os.Stderr, "error: unknown claim subcommand %q\n", sub)
+		os.Exit(int(ExitUsage))
+	}
+}
+
+// handleClaimRecord persists a pre-built claim via the public
+// [mnemos.Memory.RememberClaim] API. This is the CLI counterpart of
+// the library's Mode 3 input (agent-supplied claims); the MCP path
+// is the `remember` tool.
+func handleClaimRecord(args []string) {
+	fs := flag.NewFlagSet("claim record", flag.ContinueOnError)
+	var (
+		text       = fs.String("text", "", "claim text (required)")
+		claimType  = fs.String("type", "fact", "claim type: fact | hypothesis | decision | test_result")
+		confidence = fs.Float64("confidence", 1.0, "agent confidence in [0, 1]")
+		runID      = fs.String("run-id", "", "optional run id for scoped recall")
+		eventIDs   = fs.String("event-ids", "", "comma-separated event ids to link as evidence")
+		validFrom  = fs.String("valid-from", "", "RFC3339 timestamp when the claim first became true")
+		validUntil = fs.String("valid-until", "", "RFC3339 timestamp when the claim stopped being true")
+	)
+	if err := fs.Parse(args); err != nil {
+		exitWithMnemosError(false, NewUserError("%v", err))
+		return
+	}
+	if strings.TrimSpace(*text) == "" {
+		exitWithMnemosError(false, NewUserError("--text is required"))
+		return
+	}
+
+	item := mnemos.ClaimItem{
+		Text:       *text,
+		Type:       *claimType,
+		Confidence: *confidence,
+		RunID:      *runID,
+	}
+	if *eventIDs != "" {
+		for id := range strings.SplitSeq(*eventIDs, ",") {
+			id = strings.TrimSpace(id)
+			if id != "" {
+				item.EventIDs = append(item.EventIDs, id)
+			}
+		}
+	}
+	if s := strings.TrimSpace(*validFrom); s != "" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			exitWithMnemosError(false, NewUserError("--valid-from must be RFC3339: %v", err))
+			return
+		}
+		item.ValidFrom = t
+	}
+	if s := strings.TrimSpace(*validUntil); s != "" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			exitWithMnemosError(false, NewUserError("--valid-until must be RFC3339: %v", err))
+			return
+		}
+		item.ValidUntil = t
+	}
+
+	ctx := context.Background()
+	actor := resolveCLIActor()
+
+	mem, err := newLibraryMemory(ctx, actor)
+	if err != nil {
+		exitWithMnemosError(false, NewSystemError(err, "open memory"))
+		return
+	}
+	defer func() { _ = mem.Close() }()
+
+	id, err := mem.RememberClaim(ctx, item)
+	if err != nil {
+		exitWithMnemosError(false, NewSystemError(err, "record claim"))
+		return
+	}
+	fmt.Printf("recorded claim %s\n", id)
+}
+
+// resolveCLIActor reads MNEMOS_USER_ID for attribution, falling back
+// to a CLI-default if unset. Mirrors the MCP actor resolution but
+// uses a CLI-specific sentinel so audit can distinguish the source.
+func resolveCLIActor() string {
+	if v := os.Getenv("MNEMOS_USER_ID"); v != "" {
+		return v
+	}
+	return "<cli>"
+}

--- a/cmd/mnemos/main.go
+++ b/cmd/mnemos/main.go
@@ -192,6 +192,8 @@ func main() {
 		handleEntities(args, flags)
 	case "extract-entities":
 		handleExtractEntities(args, flags)
+	case "claim":
+		handleClaim(args, flags)
 	case "action":
 		handleAction(args, flags)
 	case "outcome":


### PR DESCRIPTION
## Summary

Adds the CLI counterpart of the library's \`RememberClaim\` (the agent-supplied input mode shipped in PR #51). Routes through the library API.

## Surface coverage for Mode 3 (agent-supplied claims)

| Surface | Call |
|---|---|
| Library | \`mem.RememberClaim(ClaimItem)\` |
| CLI | \`mnemos claim record --text ... [flags]\` ← new |
| MCP | pre-existing \`remember\` tool (creates event + claim atomically) |

## Usage

\`\`\`bash
mnemos claim record \\
  --text "User prefers Go for backend work" \\
  --type fact \\
  --confidence 0.95 \\
  --run-id session-A \\
  --event-ids evt-1,evt-2 \\
  --valid-from 2026-05-31T10:00:00Z
\`\`\`

Flags: \`--text\` (required); \`--type\` (defaults to \`fact\`); \`--confidence\` (defaults to 1.0); \`--run-id\`, \`--event-ids\` (comma-separated), \`--valid-from\`, \`--valid-until\` (both RFC3339) optional.

## Test plan

- [x] \`make check\` green
- [x] Smoke test in a fresh \`memory://\` store: \`mnemos claim record\` returns \`recorded claim cl_<id>\`
- [x] CHANGELOG updated with the new subcommand + surface coverage table