### PR TITLE
docs(changelog): promote Unreleased into v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,6 @@ Releases are tagged and published via GoReleaser; this file is the human-readabl
 
 ## [Unreleased]
 
-### Added
-- **`Memory.RememberClaim(ClaimItem)`** — third input mode for the
-  library API. Agent runtimes that have already derived structured
-  claims (with their own model or from parsed structured data) can
-  hand them to Mnemos verbatim, bypassing the extraction pipeline.
-  Companions to the existing rule-based and LLM-driven text-ingestion
-  paths. See [`docs/library.md`](docs/library.md) "Three input modes"
-  + `ExampleMemory_rememberClaim` in `example_test.go`.
-- **`mnemos claim record`** CLI subcommand — exposes the same
-  agent-supplied claim path from the command line. Flags:
-  `--text`, `--type`, `--confidence`, `--run-id`, `--event-ids`
-  (comma-separated), `--valid-from`, `--valid-until`. Routes through
-  the library API (`library_bridge.newLibraryMemory`).
-
-### Surface coverage for the third input mode
-- Library: `Memory.RememberClaim(ClaimItem)`
-- CLI: `mnemos claim record --text ... [flags]`
-- MCP: pre-existing `remember` tool (creates event + claim + evidence atomically)
-
 ## [0.17.0] — 2026-05-31
 
 Cognitive-stack simplification + embeddable library release. Mnemos
@@ -68,6 +49,22 @@ small `decisionkit` library.
   `domain.SystemUser`).
 - **Godoc examples** — `Example_passive`, `Example_sharedProvider`,
   `Example_enhanced`, `Example_withChronos` in `example_test.go`.
+
+### Added — agent-supplied claim input mode (third path)
+- **`Memory.RememberClaim(ClaimItem)`** — third input mode for the
+  library API. Agent runtimes that have already derived structured
+  claims (with their own model or from parsed structured data) can
+  hand them to Mnemos verbatim, bypassing the extraction pipeline.
+  Companions to the existing rule-based and LLM-driven text-ingestion
+  paths. See [`docs/library.md`](docs/library.md) "Three input modes"
+  + `ExampleMemory_rememberClaim` in `example_test.go`.
+- **`mnemos claim record`** CLI subcommand — exposes the same
+  agent-supplied claim path from the command line. Flags:
+  `--text`, `--type`, `--confidence`, `--run-id`, `--event-ids`
+  (comma-separated), `--valid-from`, `--valid-until`. Routes through
+  the library API (`library_bridge.newLibraryMemory`).
+- Surface coverage for Mode 3: library `Memory.RememberClaim`, CLI
+  `mnemos claim record`, MCP `remember` (pre-existing).
 
 ### Documentation
 - **ADR 0003 — Archive Olymp** (zero Go importers; orchestration patterns


### PR DESCRIPTION
Folds the agent-supplied claim input mode (RememberClaim + mnemos claim record) into the v0.17.0 entry so the tag matches what's released. No code changes.