### PR TITLE
docs(site): in-process library section + drop archived olymp ref

### DIFF
--- a/docs-site/docs/sdks/go.md
+++ b/docs-site/docs/sdks/go.md
@@ -1,6 +1,101 @@
-# Go client
+# Go SDK
 
-Lives in-tree at `github.com/felixgeelhaar/mnemos/client`. Same package as the Mnemos server itself, so it tracks the wire format precisely.
+Mnemos ships two Go surfaces. Pick whichever matches your deployment.
+
+## In-process library (v0.17+)
+
+```bash
+go get github.com/felixgeelhaar/mnemos@latest
+```
+
+Lives at `github.com/felixgeelhaar/mnemos` (the module root). Embed Mnemos
+directly in a Go agent runtime — Claude Code, Codex, Hermes, Nomi,
+OpenClaw, NanoClaw, or your own — without standing up the HTTP server.
+
+```go
+import (
+    "github.com/felixgeelhaar/mnemos"
+    _ "github.com/felixgeelhaar/mnemos/internal/store/sqlite"
+)
+
+mem, err := mnemos.New() // passive mode, XDG storage, bundled Chronos
+if err != nil { panic(err) }
+defer mem.Close()
+
+// Text in, claims out (mnemos extracts)
+_ = mem.Remember(ctx, mnemos.Item{
+    Type: "decision", Content: "Adopt Postgres for the new service.",
+})
+
+// Agent-supplied claim in (skip extraction)
+claimID, _ := mem.RememberClaim(ctx, mnemos.ClaimItem{
+    Text: "User prefers Go for backend work.",
+    Type: "fact", Confidence: 0.95,
+    EventIDs: []string{"evt-source-1"}, RunID: "session-A",
+})
+
+// Temporal
+_ = mem.RememberEvent(ctx, mnemos.Event{
+    At: time.Now(), Type: "deployment", Content: "shipped v2.3.0",
+})
+events, _ := mem.Timeline(ctx, mnemos.TimelineQuery{Types: []string{"deployment"}})
+
+// Recall
+results, _ := mem.Recall(ctx, mnemos.Query{Text: "Postgres decision", Hops: 1})
+```
+
+### Three input modes
+
+| Mode | Call | Use when |
+|---|---|---|
+| **Passive** | `Remember(Item)` + `WithPassiveMode()` | No LLM; rule-based extraction; zero per-call cost |
+| **LLM-driven** | `Remember(Item)` + `WithSharedProvider` / `WithEnhancedMode` | Prose / docs; LLM does structured extraction |
+| **Agent-supplied** | `RememberClaim(ClaimItem)` | Agent already has structured claims; skip extraction |
+
+### Three provider modes (orthogonal to input modes)
+
+- `mnemos.WithPassiveMode()` — no LLM; zero env vars
+- `mnemos.WithSharedProvider(tg, embedder)` — agent runtime hands Mnemos its
+  model client (no second API key, no duplicate config)
+- `mnemos.WithEnhancedMode(cfg)` — dedicated provider for background
+  enrichment, separate billing, local models
+
+### Framework-neutral provider interfaces
+
+```go
+import "github.com/felixgeelhaar/mnemos/providers"
+
+type myAdapter struct{ client *anthropic.Client }
+
+func (a *myAdapter) GenerateText(
+    ctx context.Context, in providers.GenerateTextInput,
+) (providers.GenerateTextOutput, error) { /* wrap your client */ }
+```
+
+### Chronos bundled
+
+`mnemos.New()` boots an in-process [Chronos](https://github.com/felixgeelhaar/chronos)
+engine (memory backend) by default so `RememberEvent` + `Timeline` work
+with zero configuration. Power users supply their own:
+
+```go
+import "github.com/felixgeelhaar/chronos/embed"
+
+eng, _ := embed.New(embed.WithStorage("sqlite:///app-chronos.db"))
+defer eng.Close()
+
+mem, _ := mnemos.New(mnemos.WithChronos(eng))
+```
+
+See [`docs/library.md`](https://github.com/felixgeelhaar/mnemos/blob/main/docs/library.md)
+in the repository for the full three-mode walkthrough.
+
+## HTTP client
+
+Lives in-tree at `github.com/felixgeelhaar/mnemos/client`. Same package as
+the Mnemos server itself, so it tracks the wire format precisely. Use
+when you want HTTP from Go (different process, registry topology, or you
+just don't want the in-process dependency on the storage drivers).
 
 ```go
 import "github.com/felixgeelhaar/mnemos/client"
@@ -12,7 +107,7 @@ hits, err := c.Search(ctx, "dietary restrictions", client.SearchOptions{TopK: 5,
 block, err := c.Context(ctx, "chat-session-1", client.ContextOptions{})
 ```
 
-## Surface
+### Surface
 
 | Method | Wraps |
 |---|---|
@@ -28,3 +123,12 @@ block, err := c.Context(ctx, "chat-session-1", client.ContextOptions{})
 | `c.Context(ctx, runID, opts)` | `GET /v1/context` |
 
 Source: [github.com/felixgeelhaar/mnemos/tree/main/client](https://github.com/felixgeelhaar/mnemos/tree/main/client).
+
+## Picking between them
+
+| You're building | Use |
+|---|---|
+| A Go agent runtime that wants Mnemos in-process | **library** (`mnemos.New`) |
+| A multi-language stack with Go just one of N callers | **HTTP client** (`mnemos/client`) against `mnemos serve` |
+| A CLI / script / one-shot tool | Either; library has lower latency, HTTP client requires a running server |
+| A registry topology (one Mnemos serving many agents) | **HTTP client** |

--- a/docs-site/docs/self-host.md
+++ b/docs-site/docs/self-host.md
@@ -42,5 +42,5 @@ Production-shape compose files live under [`deploy/`](https://github.com/felixge
 ## What the binary does NOT do
 
 - **No managed service.** Mnemos is the binary. There's no hosted version, no SOC2 reseller, no per-call meter. If you want one of those, pick a hosted competitor.
-- **No bundled UI.** A small registry browser ships at `/` (HTML at `web/index.html`); for a richer UI bring your own (the [Olymp dashboard](https://github.com/felixgeelhaar/olymp) renders Mnemos's data when wired up).
+- **No bundled UI.** A small registry browser ships at `/` (HTML at `web/index.html`); for a richer UI bring your own.
 - **No automatic backup.** Use whatever your storage backend provides (`pg_dump`, `sqlite3 .backup`, etc).


### PR DESCRIPTION
## Summary

Brings the public mkdocs site (felixgeelhaar.github.io/mnemos) in line with v0.17.0.

- **\`sdks/go.md\`**: rewrites the Go SDK page to lead with the in-process library (\`mnemos.New\`, 3 input modes, 3 provider modes, framework-neutral providers, Chronos bundled). HTTP client section follows. Adds a "picking between them" table at the end.
- **\`self-host.md\`**: drops the Olymp dashboard reference (Olymp was archived 2026-05-31).

## Test plan

- [x] No other archived-project references remain in docs-site (grep clean)