### PR TITLE
feat(library): forward RememberEvent into bundled Chronos as presence signal

### DIFF
--- a/memory_impl.go
+++ b/memory_impl.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/felixgeelhaar/chronos"
 	"github.com/felixgeelhaar/chronos/embed"
 	"github.com/felixgeelhaar/mnemos/internal/domain"
 	"github.com/felixgeelhaar/mnemos/internal/embedding"
@@ -21,7 +22,14 @@ import (
 	"github.com/felixgeelhaar/mnemos/internal/relate"
 	"github.com/felixgeelhaar/mnemos/internal/store"
 	"github.com/felixgeelhaar/mnemos/providers"
+	"github.com/google/uuid"
 )
+
+// chronosEventNamespace is the deterministic UUID namespace used when
+// hashing string ids (run id, event type) into uuid.UUID for Chronos
+// EntityState identifiers. Stable across processes so the same
+// (RunID, Type) tuple always maps to the same Chronos series.
+var chronosEventNamespace = uuid.NewSHA1(uuid.NameSpaceURL, []byte("mnemos://events"))
 
 // memory is the concrete implementation of [Memory] returned by [New].
 type memory struct {
@@ -220,9 +228,60 @@ func (m *memory) RememberEvent(ctx context.Context, e Event) error {
 	if err := m.conn.Events.Append(ctx, ev); err != nil {
 		return fmt.Errorf("mnemos: append event: %w", err)
 	}
-	// TODO(chronos): forward the event to the bundled Chronos engine
-	// for temporal pattern detection. Wiring lands in task 12.
+
+	// Forward the event to the bundled Chronos engine as a presence
+	// signal: each event maps to a single-feature EntityState at the
+	// event timestamp. This lets the detector see deployment / incident
+	// / decision bursts as recurrence + spike patterns over time.
+	//
+	// The mapping is deliberately minimal:
+	//   - EntityID  = NS-hash(event_type) so each type is its own series
+	//   - ScopeID   = NS-hash(run_id) so scopes match RememberEvent runs
+	//   - Features  = [1.0] presence indicator
+	//   - Labels    = ["event"]
+	//   - Meta      = event type + truncated content for explainability
+	//
+	// Chronos failures are non-fatal: the Mnemos event store is the
+	// source of truth and was already persisted above. Returning an
+	// error here would make a Chronos hiccup look like a Remember
+	// failure to the caller, which is wrong.
+	if m.chronos != nil {
+		_ = m.chronos.Process(ctx, m.eventToEntityState(e, id))
+	}
 	return nil
+}
+
+// eventToEntityState maps a public mnemos.Event into a chronos.EntityState
+// suitable for the bundled in-process engine. See [memory.RememberEvent]
+// for the mapping rationale.
+func (m *memory) eventToEntityState(e Event, eventID string) chronos.EntityState {
+	typ := strings.TrimSpace(e.Type)
+	if typ == "" {
+		typ = "untyped"
+	}
+	runID := e.RunID
+	if runID == "" {
+		runID = "default"
+	}
+	meta := map[string]string{
+		"mnemos_event_id": eventID,
+		"event_type":      typ,
+	}
+	if c := strings.TrimSpace(e.Content); c != "" {
+		if len(c) > 200 {
+			c = c[:200]
+		}
+		meta["content_preview"] = c
+	}
+	return chronos.EntityState{
+		ID:        uuid.New(),
+		EntityID:  uuid.NewSHA1(chronosEventNamespace, []byte(typ)),
+		ScopeID:   uuid.NewSHA1(chronosEventNamespace, []byte(runID)),
+		Timestamp: e.At.UTC(),
+		Features:  []float64{1.0},
+		Labels:    []string{"event"},
+		Meta:      meta,
+	}
 }
 
 // Timeline implements [Memory.Timeline].

--- a/memory_test.go
+++ b/memory_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/felixgeelhaar/chronos/embed"
 	"github.com/felixgeelhaar/mnemos"
 	"github.com/felixgeelhaar/mnemos/providers"
+	"github.com/google/uuid"
 
 	// Storage providers used by the tests; blank-imported here for
 	// scheme registration.
@@ -51,6 +53,55 @@ func TestNew_PassiveMode_ZeroConfig(t *testing.T) {
 	}
 	if !strings.Contains(strings.ToLower(results[0].Text), "go") {
 		t.Errorf("top result text = %q; expected to mention Go", results[0].Text)
+	}
+}
+
+// TestRememberEvent_ForwardsToBundledChronos verifies the temporal
+// path: each Mnemos event is forwarded to the bundled Chronos engine
+// as a presence signal so detectors can surface deployment / incident
+// bursts as patterns. Uses a caller-supplied Chronos engine so the
+// test can call back into it directly.
+func TestRememberEvent_ForwardsToBundledChronos(t *testing.T) {
+	t.Parallel()
+	clearMnemosEnv(t)
+
+	eng, err := embed.New(embed.WithStorage("memory://?namespace=chronos_forward_test"))
+	if err != nil {
+		t.Fatalf("embed.New: %v", err)
+	}
+	defer func() { _ = eng.Close() }()
+
+	mem, err := mnemos.New(
+		mnemos.WithStorage("memory://?namespace=mnemos_forward_test"),
+		mnemos.WithPassiveMode(),
+		mnemos.WithChronos(eng),
+	)
+	if err != nil {
+		t.Fatalf("mnemos.New: %v", err)
+	}
+	defer func() { _ = mem.Close() }()
+
+	ctx := context.Background()
+	base := time.Date(2026, 5, 31, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		if err := mem.RememberEvent(ctx, mnemos.Event{
+			At:      base.Add(time.Duration(i) * time.Minute),
+			Type:    "deployment",
+			Content: "shipped build",
+			RunID:   "forward-test",
+		}); err != nil {
+			t.Fatalf("RememberEvent[%d]: %v", i, err)
+		}
+	}
+
+	// Compute the expected ScopeID using the same NS-hash mapping the
+	// implementation uses, then run detection. We don't assert specific
+	// signals (detection thresholds may shift); we assert detection
+	// runs without error against the forwarded states.
+	ns := uuid.NewSHA1(uuid.NameSpaceURL, []byte("mnemos://events"))
+	scope := uuid.NewSHA1(ns, []byte("forward-test"))
+	if _, err := eng.Detect(ctx, []uuid.UUID{scope}); err != nil {
+		t.Errorf("eng.Detect: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes the \`TODO(chronos)\` marker left in \`memory_impl.go\` by #48.

## Mapping

Each \`mnemos.Event\` passed to \`Memory.RememberEvent\` is now also pushed to the bundled (or \`WithChronos\`-supplied) \`embed.Engine\` as a \`chronos.EntityState\`:

| Field | Value |
|---|---|
| \`EntityID\` | NS-hash(event\_type) — one series per event type |
| \`ScopeID\` | NS-hash(run\_id) — scopes mirror Mnemos run grouping |
| \`Features\` | \`[1.0]\` — presence indicator |
| \`Labels\` | \`["event"]\` |
| \`Meta\` | \`event_type\` + content preview for explainability |
| \`Timestamp\` | event's wall-clock \`At\` |

Detectors see deployment / incident / decision bursts as recurrence + spike patterns over time without requiring callers to construct numeric vectors themselves.

## Failure handling

Chronos failures are non-fatal — the Mnemos event store is the source of truth and was already persisted before the forward attempt. A Chronos hiccup must not look like a \`Remember\` failure to the caller.

## Test plan

- [x] \`TestRememberEvent_ForwardsToBundledChronos\` seeds 3 deployment events under a single run and asserts the bundled engine can run \`Detect\` on the derived \`ScopeID\`
- [x] \`make check\` green (fmt + vet + golangci-lint + race tests + build)