### PR TITLE
ci: pin goreleaser-action to '~> v2.15'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           install-only: true
+          version: '~> v2.15'
 
       - name: Validate GoReleaser config
         run: goreleaser check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: '~> v2.15'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
CI has been failing on main since v0.17.0 because goreleaser v2.16+ treats deprecated `brews` + `dockers` blocks as fatal errors. Pin the action so the existing config keeps working until a full migration to `homebrew_casks` + `dockers_v2` lands separately. Same fix already applied to chronos.