### PR TITLE
fix(integration): poll /health from runner; distroless containers can't self-check

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,24 @@ jobs:
           cache: true
 
       - name: Boot stack
-        run: docker compose -f test/integration/docker-compose.yml up -d --wait
+        # chronos + mnemos images are distroless (no shell, no wget),
+        # so docker compose's container-level healthchecks can't run.
+        # Boot detached, then poll /health from the runner host via
+        # curl until both services answer or we hit a 60s ceiling.
+        run: |
+          docker compose -f test/integration/docker-compose.yml up -d
+          deadline=$((SECONDS + 60))
+          while [ $SECONDS -lt $deadline ]; do
+            if curl -fsS http://127.0.0.1:7778/health >/dev/null \
+               && curl -fsS http://127.0.0.1:7777/health >/dev/null; then
+              echo "stack healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "stack did not become healthy in 60s"
+          docker compose -f test/integration/docker-compose.yml logs --no-color
+          exit 1
 
       - name: Smoke test
         env:

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -34,11 +34,10 @@ services:
       CHRONOS_HTTP_HOST: "0.0.0.0"
       CHRONOS_HTTP_PORT: "7778"
     command: ["serve"]
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:7778/health"]
-      interval: 2s
-      timeout: 1s
-      retries: 30
+    # No container healthcheck: the chronos image is distroless (no
+    # shell, no wget, no curl), so the previous wget-based check was
+    # never going to succeed. The Boot stack step below polls /health
+    # from the runner host instead.
 
   mnemos:
     image: ${MNEMOS_IMAGE:-ghcr.io/felixgeelhaar/mnemos:latest}
@@ -51,10 +50,5 @@ services:
       MNEMOS_HTTP_PORT: "7777"
     command: ["serve"]
     depends_on:
-      chronos:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:7777/health"]
-      interval: 2s
-      timeout: 1s
-      retries: 30
+      - chronos
+    # Same distroless caveat as chronos; runner-host poll covers it.


### PR DESCRIPTION
Following #57's memory-backend switch, integration still failed because chronos + mnemos images are distroless (no shell, no wget). Container-level healthcheck via wget can never work. Drop the inner healthcheck; poll /health from the runner host with curl until both services answer.