### PR TITLE
fix(integration): smoke test mints a JWT against shared MNEMOS_JWT_SECRET

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,6 +59,10 @@ jobs:
         env:
           CHRONOS_INTEGRATION_URL: http://127.0.0.1:7778
           MNEMOS_INTEGRATION_URL: http://127.0.0.1:7777
+          # Same secret the mnemos service uses; the smoke test mints
+          # a wildcard-scope agent JWT against it for authenticated
+          # POSTs. Local-only; not a real credential.
+          MNEMOS_JWT_SECRET: "integration-smoke-test-secret-do-not-use-anywhere-else"
         run: go test -tags=integration -v -count=1 -timeout=2m ./test/integration/...
 
       - name: Compose logs (on failure)

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -48,6 +48,12 @@ services:
       MNEMOS_DB_URL: "memory://?namespace=integration"
       MNEMOS_HTTP_HOST: "0.0.0.0"
       MNEMOS_HTTP_PORT: "7777"
+      # Fixed JWT secret for the smoke test so it can mint a wildcard-
+      # scope agent token client-side and POST authenticated writes
+      # without a real user/token provisioning pipeline. Not a
+      # security boundary: the stack only runs inside the CI runner
+      # for the duration of one job.
+      MNEMOS_JWT_SECRET: "integration-smoke-test-secret-do-not-use-anywhere-else"
     command: ["serve"]
     depends_on:
       - chronos

--- a/test/integration/smoke_test.go
+++ b/test/integration/smoke_test.go
@@ -20,8 +20,12 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/felixgeelhaar/mnemos/internal/auth"
+	"github.com/felixgeelhaar/mnemos/internal/domain"
 )
 
 func chronosBaseURL() string {
@@ -134,7 +138,17 @@ func waitForHealth(url string, total time.Duration) error {
 func postJSON(t *testing.T, url string, body any, expectStatus int) {
 	t.Helper()
 	buf, _ := json.Marshal(body)
-	resp, err := http.Post(url, "application/json", bytes.NewReader(buf))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("build POST %s: %v", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if strings.HasPrefix(url, mnemosBaseURL()) {
+		if tok := mnemosIntegrationToken(t); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("POST %s: %v", url, err)
 	}
@@ -143,6 +157,29 @@ func postJSON(t *testing.T, url string, body any, expectStatus int) {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Fatalf("POST %s status = %d, want %d (body=%s)", url, resp.StatusCode, expectStatus, string(raw))
 	}
+}
+
+// mnemosIntegrationToken mints a wildcard-scope agent JWT against the
+// shared MNEMOS_JWT_SECRET the docker-compose stack uses, so the
+// smoke test can hit authenticated POST endpoints without standing up
+// a user + token issuance pipeline. Returns "" when the secret env
+// isn't set (smoke test reads stay unauthenticated either way).
+func mnemosIntegrationToken(t *testing.T) string {
+	t.Helper()
+	secret := os.Getenv("MNEMOS_JWT_SECRET")
+	if secret == "" {
+		return ""
+	}
+	issuer := auth.NewIssuer([]byte(secret))
+	tok, _, err := issuer.IssueAgentTokenWithScopes(
+		"integration-smoke",
+		[]string{domain.ScopeWildcard},
+		15*time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("mint integration token: %v", err)
+	}
+	return tok
 }
 
 func getJSON(t *testing.T, url string) map[string]any {


### PR DESCRIPTION
After #57 + #58 unblocked the stack boot, the smoke test failed with 401 because mnemos now enforces JWT auth on POST. The pre-existing test was unauthenticated. Fix: shared MNEMOS_JWT_SECRET between the mnemos container + smoke test; client-side wildcard-scope agent JWT mint.