### PR TITLE
fix(integration): hex-encode JWT secret + decode in smoke test issuer

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,8 +61,9 @@ jobs:
           MNEMOS_INTEGRATION_URL: http://127.0.0.1:7777
           # Same secret the mnemos service uses; the smoke test mints
           # a wildcard-scope agent JWT against it for authenticated
-          # POSTs. Local-only; not a real credential.
-          MNEMOS_JWT_SECRET: "integration-smoke-test-secret-do-not-use-anywhere-else"
+          # POSTs. mnemos expects hex-encoded; this matches the value
+          # in docker-compose.yml. Local-only; not a real credential.
+          MNEMOS_JWT_SECRET: "21201b428a0b19d5fb348947b4a98455ece9ccd6230d65b27fe178596f082ce1"
         run: go test -tags=integration -v -count=1 -timeout=2m ./test/integration/...
 
       - name: Compose logs (on failure)

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -50,10 +50,11 @@ services:
       MNEMOS_HTTP_PORT: "7777"
       # Fixed JWT secret for the smoke test so it can mint a wildcard-
       # scope agent token client-side and POST authenticated writes
-      # without a real user/token provisioning pipeline. Not a
-      # security boundary: the stack only runs inside the CI runner
-      # for the duration of one job.
-      MNEMOS_JWT_SECRET: "integration-smoke-test-secret-do-not-use-anywhere-else"
+      # without a real user/token provisioning pipeline. mnemos expects
+      # hex-encoded; this is sha256("integration-smoke-mnemos-test").
+      # Not a security boundary: the stack only runs inside the CI
+      # runner for the duration of one job.
+      MNEMOS_JWT_SECRET: "21201b428a0b19d5fb348947b4a98455ece9ccd6230d65b27fe178596f082ce1"
     command: ["serve"]
     depends_on:
       - chronos

--- a/test/integration/smoke_test.go
+++ b/test/integration/smoke_test.go
@@ -15,6 +15,7 @@ package integration
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -164,13 +165,21 @@ func postJSON(t *testing.T, url string, body any, expectStatus int) {
 // smoke test can hit authenticated POST endpoints without standing up
 // a user + token issuance pipeline. Returns "" when the secret env
 // isn't set (smoke test reads stay unauthenticated either way).
+//
+// mnemos serve loads MNEMOS_JWT_SECRET as a hex-encoded byte string;
+// the smoke test decodes here so the issuer signs with the same raw
+// bytes the server verifies against.
 func mnemosIntegrationToken(t *testing.T) string {
 	t.Helper()
-	secret := os.Getenv("MNEMOS_JWT_SECRET")
-	if secret == "" {
+	secretHex := os.Getenv("MNEMOS_JWT_SECRET")
+	if secretHex == "" {
 		return ""
 	}
-	issuer := auth.NewIssuer([]byte(secret))
+	secret, err := hex.DecodeString(secretHex)
+	if err != nil {
+		t.Fatalf("MNEMOS_JWT_SECRET must be hex: %v", err)
+	}
+	issuer := auth.NewIssuer(secret)
 	tok, _, err := issuer.IssueAgentTokenWithScopes(
 		"integration-smoke",
 		[]string{domain.ScopeWildcard},


### PR DESCRIPTION
mnemos serve requires hex-encoded MNEMOS_JWT_SECRET; #59 supplied a plain string. Switch to a 64-char hex value (sha256 of an integration-only label) and decode it client-side so the issuer signs with the matching raw bytes.