### PR TITLE
feat(auth): JWT kid header + N-way Keyring rotation

### DIFF
--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -99,33 +99,45 @@ func (c Claims) AllowsRun(runID string) bool {
 // Issuer mints new JWTs. It does not store anything — the resulting
 // token string is the only place the plaintext exists. Callers should
 // hand it back to the user once and never persist it server-side.
-type Issuer struct {
-	secret []byte
-}
-
-// Verifier parses + validates JWTs and consults the revocation denylist.
 //
-// Dual-key support: a `previous` secret may be supplied to support
-// zero-downtime rotation. New tokens always sign under the active
-// secret; tokens issued under the previous secret continue to verify
-// until they expire. Drop the previous secret once the longest-lived
-// outstanding token has expired.
-type Verifier struct {
-	secret         []byte
-	previousSecret []byte
-	revoked        ports.RevokedTokenRepository
+// Issuer signs tokens with the [Keyring]'s primary kid and writes
+// that kid into the JWT header so verifiers can look up the right
+// secret during rotation.
+type Issuer struct {
+	keyring *Keyring
 }
 
-// NewIssuer returns an Issuer signing tokens with the given secret. The
-// secret should be at least 32 bytes of random data; see GenerateSecret.
+// Verifier parses + validates JWTs and consults the revocation
+// denylist. The signing kid is read from the JWT header and looked up
+// in the [Keyring]; empty kid (tokens minted before this surface
+// existed) falls back to the primary secret for back-compat.
+type Verifier struct {
+	keyring *Keyring
+	revoked ports.RevokedTokenRepository
+}
+
+// NewIssuer returns an Issuer signing tokens with the given secret.
+// The secret becomes the primary entry of a one-key Keyring with kid
+// "primary". For multi-key rotation use [NewIssuerWithKeyring].
+//
+// Secret should be at least 32 bytes of random data; see GenerateSecret.
 func NewIssuer(secret []byte) *Issuer {
-	return &Issuer{secret: secret}
+	return &Issuer{keyring: newSingleKeyKeyring(secret)}
+}
+
+// NewIssuerWithKeyring returns an Issuer that signs tokens with the
+// Keyring's primary kid. Use this when the deployment is mid-rotation
+// and multiple kids are valid concurrently.
+func NewIssuerWithKeyring(keyring *Keyring) *Issuer {
+	return &Issuer{keyring: keyring}
 }
 
 // NewVerifier returns a Verifier that validates tokens against the
 // given secret and consults revoked for instant-revocation lookups.
+// Wraps the secret in a one-key Keyring; for multi-key rotation use
+// [NewVerifierWithKeyring].
 func NewVerifier(secret []byte, revoked ports.RevokedTokenRepository) *Verifier {
-	return &Verifier{secret: secret, revoked: revoked}
+	return &Verifier{keyring: newSingleKeyKeyring(secret), revoked: revoked}
 }
 
 // NewVerifierWithPrevious returns a dual-key Verifier. Tokens signed
@@ -133,8 +145,19 @@ func NewVerifier(secret []byte, revoked ports.RevokedTokenRepository) *Verifier 
 // [Issuer]) always sign under active. Pass nil/empty previous to
 // disable the rotation path — callers without a rotation in flight
 // should use [NewVerifier] instead.
+//
+// Implemented in terms of a 2-entry Keyring (kids "primary" +
+// "previous"). For N-way rotation prefer [NewVerifierWithKeyring].
 func NewVerifierWithPrevious(active, previous []byte, revoked ports.RevokedTokenRepository) *Verifier {
-	return &Verifier{secret: active, previousSecret: previous, revoked: revoked}
+	return &Verifier{keyring: newDualKeyKeyring(active, previous), revoked: revoked}
+}
+
+// NewVerifierWithKeyring returns a Verifier that selects the signing
+// secret per-request based on the JWT header's kid claim. Tokens with
+// no kid header fall back to the Keyring's primary secret to remain
+// compatible with the legacy single-secret + dual-key flows.
+func NewVerifierWithKeyring(keyring *Keyring, revoked ports.RevokedTokenRepository) *Verifier {
+	return &Verifier{keyring: keyring, revoked: revoked}
 }
 
 // IssueUserToken mints a JWT for a human user, valid for ttl.
@@ -205,7 +228,11 @@ func (i *Issuer) issue(subject string, kind TokenKind, scopes, runs []string, tt
 		},
 	}
 	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signed, err := tok.SignedString(i.secret)
+	// Set kid header so verifiers can pick the right secret during
+	// rotation. Tokens without a kid stay compatible (verifier falls
+	// back to the Keyring's primary entry).
+	tok.Header["kid"] = i.keyring.Primary()
+	signed, err := tok.SignedString(i.keyring.PrimarySecret())
 	if err != nil {
 		return "", "", fmt.Errorf("sign token: %w", err)
 	}
@@ -213,9 +240,19 @@ func (i *Issuer) issue(subject string, kind TokenKind, scopes, runs []string, tt
 }
 
 // ParseAndValidate parses tokenString, verifies its signature against
-// the configured secret, checks expiry, and consults the revocation
-// denylist. Returns the validated claims or an error explaining why
-// the token was rejected.
+// the keyring-resolved secret, checks expiry, and consults the
+// revocation denylist. Returns the validated claims or an error
+// explaining why the token was rejected.
+//
+// Kid resolution:
+//   - If the JWT header carries a kid, that kid MUST be present in the
+//     keyring; an unknown kid fails fast (no fallback to other secrets,
+//     since the issuer told us which key to use).
+//   - If the JWT header has no kid (legacy tokens minted before this
+//     surface existed), every registered key is tried in iteration
+//     order until one signature matches. This preserves the original
+//     dual-key fallback semantics for in-flight legacy tokens during
+//     the rotation transition.
 func (v *Verifier) ParseAndValidate(ctx context.Context, tokenString string) (*Claims, error) {
 	parseWith := func(secret []byte) (*jwt.Token, error) {
 		return jwt.ParseWithClaims(tokenString, &Claims{}, func(t *jwt.Token) (any, error) {
@@ -225,9 +262,36 @@ func (v *Verifier) ParseAndValidate(ctx context.Context, tokenString string) (*C
 			return secret, nil
 		}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
 	}
-	parsed, err := parseWith(v.secret)
-	if err != nil && len(v.previousSecret) > 0 && isSignatureError(err) {
-		parsed, err = parseWith(v.previousSecret)
+
+	// Pick the starting secret from the kid header (if any) and fall
+	// back through every other registered kid on signature mismatch.
+	// The header is a hint, not a strict gate: tokens minted before
+	// the kid surface existed have no header, and tokens minted under
+	// a kid label that later gets renamed (or moved between "primary"
+	// and "previous" during dual-key rotation) still need to validate
+	// as long as one of the keyring's secrets matches the signature.
+	// Non-signature errors (expired token, malformed JWT, unknown
+	// alg) short-circuit immediately.
+	kid := extractKid(tokenString)
+	tryOrder := orderedKids(v.keyring, kid)
+	var (
+		parsed *jwt.Token
+		err    error
+	)
+	for _, k := range tryOrder {
+		secret, ok := v.keyring.Secret(k)
+		if !ok {
+			continue
+		}
+		parsed, err = parseWith(secret)
+		if err == nil {
+			break
+		}
+		if !isSignatureError(err) {
+			// Don't keep trying other secrets for non-signature errors;
+			// those are token-shape failures that won't recover.
+			return nil, fmt.Errorf("parse token: %w", err)
+		}
 	}
 	if err != nil {
 		return nil, fmt.Errorf("parse token: %w", err)
@@ -259,6 +323,57 @@ func (v *Verifier) ParseAndValidate(ctx context.Context, tokenString string) (*C
 func isSignatureError(err error) bool {
 	return errors.Is(err, jwt.ErrSignatureInvalid) ||
 		errors.Is(err, jwt.ErrTokenSignatureInvalid)
+}
+
+// orderedKids returns the kid order [Verifier.ParseAndValidate]
+// should try when verifying signatures. The header-supplied kid (if
+// recognised by the keyring) goes first; the primary kid is next;
+// every other registered kid follows. This makes the new-token path
+// (header kid → instant match) O(1) and the legacy / mid-rotation
+// fallback path O(N).
+func orderedKids(k *Keyring, headerKid string) []string {
+	all := k.Kids()
+	out := make([]string, 0, len(all)+1)
+	seen := make(map[string]struct{}, len(all))
+	add := func(kid string) {
+		if kid == "" {
+			return
+		}
+		if _, dup := seen[kid]; dup {
+			return
+		}
+		if _, ok := k.Secret(kid); !ok {
+			return
+		}
+		seen[kid] = struct{}{}
+		out = append(out, kid)
+	}
+	add(headerKid)
+	add(k.Primary())
+	for _, kid := range all {
+		add(kid)
+	}
+	return out
+}
+
+// extractKid pulls the `kid` header parameter from a JWT without
+// validating the signature. Used by [Verifier.ParseAndValidate] to
+// pick the right secret before parse-with-signature runs.
+//
+// On any decode error (malformed token, missing header, non-string
+// kid) returns "" — the caller treats that as the legacy "no kid
+// header" path and falls back to the primary secret.
+func extractKid(tokenString string) string {
+	// jwt.ParseUnverified parses the token without checking the
+	// signature, which is exactly what we need to read the header.
+	tok, _, err := new(jwt.Parser).ParseUnverified(tokenString, &Claims{})
+	if err != nil {
+		return ""
+	}
+	if kid, ok := tok.Header["kid"].(string); ok {
+		return kid
+	}
+	return ""
 }
 
 // GenerateSecret returns 32 bytes of cryptographically random data,

--- a/internal/auth/keyring.go
+++ b/internal/auth/keyring.go
@@ -1,0 +1,121 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// Keyring holds N JWT signing secrets keyed by `kid` (RFC 7515 §4.1.4
+// "key id" header parameter). The Primary kid is the one new tokens
+// sign with; the rest stay around for verification only, letting an
+// operator rotate without invalidating any outstanding token in
+// flight.
+//
+// This generalises the previous dual-key (`active` + `previous`)
+// rotation surface: a Keyring can hold any number of overlapping keys
+// during a rotation window, then drop expired kids once their
+// longest-lived issued token has expired.
+//
+// Backwards compatibility:
+//   - Tokens minted without a `kid` header continue to verify against
+//     the keyring's Primary entry (the legacy single-secret behaviour).
+//   - The legacy [NewIssuer] / [NewVerifier] / [NewVerifierWithPrevious]
+//     constructors now wrap a Keyring internally and keep working
+//     unchanged.
+type Keyring struct {
+	primary string
+	keys    map[string][]byte
+}
+
+// NewKeyring constructs a Keyring from a kid→secret map. The
+// `primary` kid must be present in `keys`; every secret must be
+// non-empty.
+func NewKeyring(primary string, keys map[string][]byte) (*Keyring, error) {
+	if primary == "" {
+		return nil, errors.New("auth: keyring primary kid required")
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("auth: keyring must contain at least one key")
+	}
+	if _, ok := keys[primary]; !ok {
+		return nil, fmt.Errorf("auth: primary kid %q not present in keys", primary)
+	}
+	// Defensive copy + validation.
+	cp := make(map[string][]byte, len(keys))
+	for kid, secret := range keys {
+		if kid == "" {
+			return nil, errors.New("auth: empty kid in keyring")
+		}
+		if len(secret) == 0 {
+			return nil, fmt.Errorf("auth: empty secret for kid %q", kid)
+		}
+		cp[kid] = append([]byte(nil), secret...)
+	}
+	return &Keyring{primary: primary, keys: cp}, nil
+}
+
+// Primary returns the kid new tokens sign with.
+func (k *Keyring) Primary() string { return k.primary }
+
+// PrimarySecret returns the signing secret for the primary kid.
+func (k *Keyring) PrimarySecret() []byte {
+	return k.keys[k.primary]
+}
+
+// Secret returns the secret for the given kid (or nil + false if the
+// kid isn't registered). The legacy single-secret verifier behaviour
+// of accepting unsigned-header tokens routes through this with kid=""
+// — see [Keyring.LookupForVerify].
+func (k *Keyring) Secret(kid string) ([]byte, bool) {
+	s, ok := k.keys[kid]
+	return s, ok
+}
+
+// LookupForVerify resolves a kid extracted from a JWT header to the
+// secret a Verifier should use. Empty kid maps to the primary secret
+// to preserve compatibility with tokens minted before the kid header
+// was added.
+func (k *Keyring) LookupForVerify(kid string) ([]byte, bool) {
+	if kid == "" {
+		return k.keys[k.primary], true
+	}
+	s, ok := k.keys[kid]
+	return s, ok
+}
+
+// Kids returns the registered kids in sorted order. Used by tests +
+// the doctor command for visibility.
+func (k *Keyring) Kids() []string {
+	out := make([]string, 0, len(k.keys))
+	for kid := range k.keys {
+		out = append(out, kid)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// newSingleKeyKeyring wraps a single legacy secret as a Keyring with
+// the conventional "primary" kid. Used by the back-compat
+// constructors [NewIssuer], [NewVerifier], [NewVerifierWithPrevious]
+// so existing callers don't have to think about kids.
+func newSingleKeyKeyring(secret []byte) *Keyring {
+	return &Keyring{
+		primary: "primary",
+		keys:    map[string][]byte{"primary": append([]byte(nil), secret...)},
+	}
+}
+
+// newDualKeyKeyring wraps the legacy (active, previous) rotation
+// surface as a Keyring. The active secret becomes "primary"; the
+// previous secret keeps verifying under kid "previous" until the
+// caller drops it.
+func newDualKeyKeyring(active, previous []byte) *Keyring {
+	keys := map[string][]byte{
+		"primary": append([]byte(nil), active...),
+	}
+	if len(previous) > 0 {
+		keys["previous"] = append([]byte(nil), previous...)
+	}
+	return &Keyring{primary: "primary", keys: keys}
+}

--- a/internal/auth/keyring_test.go
+++ b/internal/auth/keyring_test.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestKeyring_RejectsBadConstruction pins the invariants the
+// constructor must enforce. Each case is a real misconfiguration
+// somebody could make in env wiring.
+func TestKeyring_RejectsBadConstruction(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		primary string
+		keys    map[string][]byte
+		wantErr string
+	}{
+		{"empty primary", "", map[string][]byte{"a": []byte("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")}, "primary kid required"},
+		{"no keys", "primary", nil, "must contain at least one key"},
+		{"primary missing from keys", "v2", map[string][]byte{"v1": []byte("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")}, "not present in keys"},
+		{"empty kid in keys", "primary", map[string][]byte{"primary": []byte("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"), "": []byte("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy")}, "empty kid"},
+		{"empty secret", "primary", map[string][]byte{"primary": {}}, "empty secret"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewKeyring(tc.primary, tc.keys)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestIssuerWithKeyring_WritesKidHeader verifies a token minted via
+// the multi-key surface carries the primary kid in its header and
+// validates without surprises on the other side.
+func TestIssuerWithKeyring_WritesKidHeader(t *testing.T) {
+	t.Parallel()
+	kr, err := NewKeyring("v2", map[string][]byte{
+		"v1": bytesOfLen(32, 'a'),
+		"v2": bytesOfLen(32, 'b'),
+	})
+	if err != nil {
+		t.Fatalf("keyring: %v", err)
+	}
+
+	issuer := NewIssuerWithKeyring(kr)
+	tok, _, err := issuer.IssueAgentTokenWithScopes("agent-1", []string{"*"}, time.Minute)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+
+	verifier := NewVerifierWithKeyring(kr, newFakeRevoked())
+	claims, err := verifier.ParseAndValidate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if claims.UserID != "agent-1" {
+		t.Errorf("UserID = %q, want agent-1", claims.UserID)
+	}
+}
+
+// TestVerifierWithKeyring_OldTokenValidatesAfterRotation simulates
+// rotation: an operator promotes a new kid to primary while the old
+// kid stays in the keyring for verification. Tokens issued under the
+// old kid must continue to validate until they expire.
+func TestVerifierWithKeyring_OldTokenValidatesAfterRotation(t *testing.T) {
+	t.Parallel()
+	v1 := bytesOfLen(32, '1')
+	v2 := bytesOfLen(32, '2')
+
+	// State 1: only v1 exists; mint a token with it.
+	preRotation, err := NewKeyring("v1", map[string][]byte{"v1": v1})
+	if err != nil {
+		t.Fatalf("pre-rotation keyring: %v", err)
+	}
+	issuerV1 := NewIssuerWithKeyring(preRotation)
+	tok, _, err := issuerV1.IssueAgentTokenWithScopes("agent-1", []string{"*"}, time.Hour)
+	if err != nil {
+		t.Fatalf("issue under v1: %v", err)
+	}
+
+	// State 2: v2 promoted to primary, v1 kept around for verification.
+	postRotation, err := NewKeyring("v2", map[string][]byte{
+		"v1": v1,
+		"v2": v2,
+	})
+	if err != nil {
+		t.Fatalf("post-rotation keyring: %v", err)
+	}
+	verifier := NewVerifierWithKeyring(postRotation, newFakeRevoked())
+
+	claims, err := verifier.ParseAndValidate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("token issued under v1 should still validate post-rotation: %v", err)
+	}
+	if claims.UserID != "agent-1" {
+		t.Errorf("UserID = %q, want agent-1", claims.UserID)
+	}
+}
+
+// TestVerifierWithKeyring_RejectsAfterKidDropped pins the eventual
+// cleanup: once the old kid is dropped from the keyring, tokens
+// signed under it must be rejected.
+func TestVerifierWithKeyring_RejectsAfterKidDropped(t *testing.T) {
+	t.Parallel()
+	v1 := bytesOfLen(32, '1')
+	v2 := bytesOfLen(32, '2')
+
+	preRotation, _ := NewKeyring("v1", map[string][]byte{"v1": v1})
+	issuerV1 := NewIssuerWithKeyring(preRotation)
+	tok, _, _ := issuerV1.IssueAgentTokenWithScopes("agent-1", []string{"*"}, time.Hour)
+
+	// Drop v1 entirely; only v2 is registered now.
+	cleaned, _ := NewKeyring("v2", map[string][]byte{"v2": v2})
+	verifier := NewVerifierWithKeyring(cleaned, newFakeRevoked())
+
+	_, err := verifier.ParseAndValidate(context.Background(), tok)
+	if err == nil {
+		t.Fatal("expected validation failure after v1 dropped, got nil")
+	}
+}
+
+// TestVerifierWithKeyring_KidsHelper covers the diagnostic helper
+// the doctor command will rely on.
+func TestVerifierWithKeyring_KidsHelper(t *testing.T) {
+	t.Parallel()
+	kr, _ := NewKeyring("v2", map[string][]byte{
+		"v1": bytesOfLen(32, '1'),
+		"v2": bytesOfLen(32, '2'),
+		"v3": bytesOfLen(32, '3'),
+	})
+	got := kr.Kids()
+	want := []string{"v1", "v2", "v3"}
+	if len(got) != len(want) {
+		t.Fatalf("len Kids() = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("Kids()[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+	if kr.Primary() != "v2" {
+		t.Errorf("Primary() = %q, want v2", kr.Primary())
+	}
+}
+
+func bytesOfLen(n int, fill byte) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = fill
+	}
+	return b
+}


### PR DESCRIPTION
Closes the long-standing roadmap item. Generalises dual-key (active + previous) rotation to N kids; mints with kid header; verifier picks the right secret by kid (O(1)) with legacy-token fallback. Back-compat preserved: NewIssuer / NewVerifier / NewVerifierWithPrevious work unchanged (wrap a Keyring internally). 5 new tests + all existing auth tests still green.