### PR TITLE
ci(lint): drop gosec — security owned by nox

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,8 +5,9 @@ run:
 
 linters:
   # Org engineering bar (klarlabs-studio golangci.reference.yml) merged with
-  # mnemos-specific opt-ins. gocritic + gosec are part of the shared gate and
-  # must stay enabled. revive is a repo-specific opt-in (exported-symbol docs).
+  # mnemos-specific opt-ins. gocritic is part of the shared gate and must stay
+  # enabled; code-level security is owned by nox. revive is a repo-specific
+  # opt-in (exported-symbol docs).
   default: standard
   enable:
     - errcheck
@@ -18,7 +19,6 @@ linters:
     - unconvert
     - unparam
     - gocritic     # org engineering bar — do not drop
-    - gosec
     - revive       # repo-specific: enforce exported-symbol documentation
 
   settings:
@@ -28,10 +28,6 @@ linters:
           severity: warning
           arguments:
             - checkPrivateReceivers
-    gosec:
-      excludes:
-        - G115 # integer overflow conversion — not applicable in this codebase
-        - G703 # path traversal — operator-supplied config paths, not user input
     gocritic:
       disabled-checks:
         # `unlambda` flags trivial wrapper closures that document the
@@ -48,19 +44,10 @@ linters:
 
   exclusions:
     rules:
-      # Tests legitimately ignore encode errors (test handlers) and use
-      # math/rand for deterministic fixtures. gosec does not apply to test code.
-      - linters: [gosec]
-        path: _test\.go
       # Test helpers keep constant-valued params and symmetric return
       # values for readability and future fixtures; unparam is noise here.
       - linters: [unparam]
         path: _test\.go
-      # Ignore gosec inline nolint directives
-      - linters: [gosec]
-        text: "G201"
-      - linters: [gosec]
-        text: "G304"
     paths:
       - data/eval
 

--- a/cmd/mnemos/gitcontext.go
+++ b/cmd/mnemos/gitcontext.go
@@ -76,7 +76,7 @@ func runGitLog(ctx context.Context, repoRoot string, limit int, since string) ([
 		args = append(args, "--since="+strings.TrimSpace(since))
 	}
 
-	cmd := exec.CommandContext(ctx, "git", args...) //nolint:gosec // G204: git args are constructed from validated inputs
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {

--- a/cmd/mnemos/markdown.go
+++ b/cmd/mnemos/markdown.go
@@ -87,7 +87,7 @@ func handleExport(args []string, _ Flags) {
 		fmt.Print(rendered)
 		return
 	}
-	if err := os.WriteFile(out, []byte(rendered), 0o600); err != nil { //nolint:gosec // G304: --out path is the operator's choice
+	if err := os.WriteFile(out, []byte(rendered), 0o600); err != nil {
 		exitWithMnemosError(false, NewSystemError(err, "write file"))
 		return
 	}
@@ -131,7 +131,7 @@ func handleImport(args []string, _ Flags) {
 		return
 	}
 	path := args[0]
-	data, err := os.ReadFile(path) //nolint:gosec // G304: caller-supplied path is the operator's choice
+	data, err := os.ReadFile(path)
 	if err != nil {
 		exitWithMnemosError(false, NewSystemError(err, "read file"))
 		return

--- a/cmd/mnemos/prcontext.go
+++ b/cmd/mnemos/prcontext.go
@@ -60,7 +60,7 @@ func runGhPRs(ctx context.Context, repoRoot string, limit int) ([]prRecord, erro
 		limit = maxGitPRLimit
 	}
 
-	cmd := exec.CommandContext(ctx, "gh", //nolint:gosec // G204: args constructed from validated inputs
+	cmd := exec.CommandContext(ctx, "gh",
 		"pr", "list",
 		"--state", "merged",
 		"--limit", strconv.Itoa(limit),

--- a/cmd/mnemos/registry.go
+++ b/cmd/mnemos/registry.go
@@ -83,7 +83,7 @@ func loadProjectConfig() (registryConfig, error) {
 	if err != nil {
 		return registryConfig{}, err
 	}
-	data, err := os.ReadFile(p) //nolint:gosec // G304: project config in user-owned .mnemos directory
+	data, err := os.ReadFile(p)
 	if err != nil {
 		return registryConfig{}, err
 	}
@@ -459,7 +459,7 @@ func pushBatched(ctx context.Context, client *http.Client, endpoint, token, reso
 		if err != nil {
 			return totalAccepted, fmt.Errorf("encode %s batch %d: %w", resource, i, err)
 		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(buf)) //nolint:gosec // G704: endpoint is operator-supplied via env/config, not user-supplied input
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(buf))
 		if err != nil {
 			return totalAccepted, fmt.Errorf("build %s request: %w", resource, err)
 		}
@@ -467,7 +467,7 @@ func pushBatched(ctx context.Context, client *http.Client, endpoint, token, reso
 		if token != "" {
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
-		resp, err := client.Do(req) //nolint:gosec // G704: same operator-supplied endpoint as request
+		resp, err := client.Do(req)
 		if err != nil {
 			return totalAccepted, fmt.Errorf("post %s batch %d: %w", resource, i, err)
 		}
@@ -550,14 +550,14 @@ func pullRelationships(ctx context.Context, client *http.Client, regURL, token s
 }
 
 func fetchPage(ctx context.Context, client *http.Client, endpoint, token string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil) //nolint:gosec // G704: endpoint is operator-supplied via env/config, not user-supplied input
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	resp, err := client.Do(req) //nolint:gosec // G704: same operator-supplied endpoint as request
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/mnemos/serve.go
+++ b/cmd/mnemos/serve.go
@@ -2458,7 +2458,7 @@ func makeClaimMarkdownExportHandler(conn *store.Conn, claimID string) http.Handl
 		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.md"`, claimID))
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(rendered)) //nolint:gosec // G705: rendered is produced by our own markdown.ExportClaim, not from user input
+		_, _ = w.Write([]byte(rendered))
 	}
 }
 

--- a/cmd/mnemos/telemetry.go
+++ b/cmd/mnemos/telemetry.go
@@ -267,14 +267,14 @@ func sendTelemetry(ctx context.Context, m WorkspaceMetrics) (sent bool, err erro
 	}
 	// Endpoint is operator-supplied via MNEMOS_TELEMETRY_ENDPOINT and gated
 	// by an explicit opt-in marker; gosec G107/G104 are accepted here.
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body)) //nolint:gosec
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return false, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "mnemos-cli/"+mnemosVersion())
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req) //nolint:gosec
+	resp, err := client.Do(req)
 	if err != nil {
 		return false, fmt.Errorf("post: %w", err)
 	}

--- a/cmd/mnemos/watch.go
+++ b/cmd/mnemos/watch.go
@@ -177,7 +177,7 @@ func (w *Watcher) tick(ctx context.Context) (changed, removed int) {
 
 // hashFile returns the hex-encoded sha256 of the file at path.
 func hashFile(path string) (string, error) {
-	data, err := os.ReadFile(path) //nolint:gosec // G304: watcher reads user-registered files by design
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("read %s: %w", path, err)
 	}

--- a/internal/auth/secret.go
+++ b/internal/auth/secret.go
@@ -34,7 +34,7 @@ func LoadOrCreateSecret(path string) ([]byte, bool, error) {
 		return nil, false, errors.New("no secret path provided and MNEMOS_JWT_SECRET unset")
 	}
 
-	if data, err := os.ReadFile(path); err == nil { //nolint:gosec // G304: server-resolved path
+	if data, err := os.ReadFile(path); err == nil {
 		decoded, err := hex.DecodeString(strings.TrimSpace(string(data)))
 		if err != nil {
 			return nil, false, fmt.Errorf("read %s: not hex-encoded: %w", path, err)
@@ -83,7 +83,7 @@ func LoadPreviousSecret(activePath string) ([]byte, error) {
 		return nil, nil
 	}
 	prevPath := activePath + ".previous"
-	data, err := os.ReadFile(prevPath) //nolint:gosec // G304: server-resolved path
+	data, err := os.ReadFile(prevPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil

--- a/internal/embedding/http.go
+++ b/internal/embedding/http.go
@@ -37,11 +37,11 @@ func envDuration(envVar string, def time.Duration) time.Duration {
 	}
 	d, err := time.ParseDuration(raw)
 	if err != nil {
-		log.Printf("invalid %s=%q (want a Go duration like 60s or 2m): %v; using %s", envVar, sanitizeForLog(raw), err, def) //nolint:gosec // value is %q-quoted and length-bounded
+		log.Printf("invalid %s=%q (want a Go duration like 60s or 2m): %v; using %s", envVar, sanitizeForLog(raw), err, def)
 		return def
 	}
 	if d <= 0 {
-		log.Printf("invalid %s=%q (must be > 0); using %s", envVar, sanitizeForLog(raw), def) //nolint:gosec // value is %q-quoted and length-bounded
+		log.Printf("invalid %s=%q (must be > 0); using %s", envVar, sanitizeForLog(raw), def)
 		return def
 	}
 	return d

--- a/internal/ingest/input_service.go
+++ b/internal/ingest/input_service.go
@@ -36,7 +36,7 @@ func (s Service) IngestFile(path string) (domain.Input, string, error) {
 		return domain.Input{}, "", errors.New("path is required")
 	}
 
-	contentBytes, err := os.ReadFile(path) //nolint:gosec // G304: CLI tool reads user-specified files by design
+	contentBytes, err := os.ReadFile(path)
 	if err != nil {
 		return domain.Input{}, "", fmt.Errorf("read input file: %w", err)
 	}

--- a/internal/llm/helpers.go
+++ b/internal/llm/helpers.go
@@ -50,11 +50,11 @@ func envDuration(envVar string, def time.Duration) time.Duration {
 	d, err := time.ParseDuration(raw)
 	if err != nil {
 		// %q quotes and escapes; envVar is hard-coded by callers.
-		log.Printf("invalid %s=%q (want a Go duration like 60s or 2m): %v; using %s", envVar, sanitizeForLog(raw), err, def) //nolint:gosec // value is %q-quoted and length-bounded
+		log.Printf("invalid %s=%q (want a Go duration like 60s or 2m): %v; using %s", envVar, sanitizeForLog(raw), err, def)
 		return def
 	}
 	if d <= 0 {
-		log.Printf("invalid %s=%q (must be > 0); using %s", envVar, sanitizeForLog(raw), def) //nolint:gosec // value is %q-quoted and length-bounded
+		log.Printf("invalid %s=%q (must be > 0); using %s", envVar, sanitizeForLog(raw), def)
 		return def
 	}
 	return d

--- a/internal/store/mysql/claim_repository.go
+++ b/internal/store/mysql/claim_repository.go
@@ -130,7 +130,6 @@ func (r ClaimRepository) ListByEventIDs(ctx context.Context, eventIDs []string) 
 		return []domain.Claim{}, nil
 	}
 	placeholders, args := inPlaceholders(eventIDs)
-	//nolint:gosec // G202: placeholders are literal "?" tokens, not user input
 	q := `
 SELECT DISTINCT c.id, c.text, c.type, c.confidence, c.status, c.created_at, c.created_by, c.trust_score, c.valid_from, c.valid_to
 FROM claims c
@@ -151,7 +150,6 @@ func (r ClaimRepository) ListEvidenceByClaimIDs(ctx context.Context, claimIDs []
 		return []domain.ClaimEvidence{}, nil
 	}
 	placeholders, args := inPlaceholders(claimIDs)
-	//nolint:gosec // G202: placeholders are literal "?" tokens, not user input
 	rows, err := r.db.QueryContext(ctx, `SELECT claim_id, event_id FROM claim_evidence WHERE claim_id IN (`+placeholders+`)`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list evidence by claim ids: %w", err)
@@ -174,7 +172,6 @@ func (r ClaimRepository) ListByIDs(ctx context.Context, claimIDs []string) ([]do
 		return []domain.Claim{}, nil
 	}
 	placeholders, args := inPlaceholders(claimIDs)
-	//nolint:gosec // G202: placeholders are literal "?" tokens, not user input
 	rows, err := r.db.QueryContext(ctx, `
 SELECT id, text, type, confidence, status, created_at, created_by, trust_score, valid_from, valid_to
 FROM claims WHERE id IN (`+placeholders+`)`, args...)

--- a/internal/store/mysql/event_repository.go
+++ b/internal/store/mysql/event_repository.go
@@ -64,7 +64,6 @@ func (r EventRepository) ListByIDs(ctx context.Context, ids []string) ([]domain.
 		return []domain.Event{}, nil
 	}
 	placeholders, args := inPlaceholders(ids)
-	//nolint:gosec // G202: placeholders are literal "?" tokens, not user input
 	q := `SELECT id, run_id, schema_version, content, source_input_id, timestamp, metadata_json, ingested_at, created_by
 FROM events WHERE id IN (` + placeholders + `)`
 	rows, err := r.db.QueryContext(ctx, q, args...)

--- a/internal/store/mysql/relationship_repository.go
+++ b/internal/store/mysql/relationship_repository.go
@@ -174,7 +174,6 @@ func (r RelationshipRepository) ListByClaimIDs(ctx context.Context, claimIDs []s
 	placeholders, args := inPlaceholders(claimIDs)
 	// Same args twice for from_claim_id and to_claim_id IN clauses.
 	args2 := append(append([]any{}, args...), args...)
-	//nolint:gosec // G202: placeholders are literal "?" tokens, not user input
 	q := `
 SELECT id, type, from_claim_id, to_claim_id, created_at, created_by
 FROM relationships

--- a/internal/store/mysql/user_repository.go
+++ b/internal/store/mysql/user_repository.go
@@ -95,7 +95,6 @@ func (r UserRepository) UpdateScopes(ctx context.Context, id string, scopes []st
 }
 
 func (r UserRepository) scanOne(ctx context.Context, where string, args ...any) (domain.User, error) {
-	//nolint:gosec // G202: where is one of two literal constants from internal callers, never user input
 	row := r.db.QueryRowContext(ctx, `SELECT id, name, email, status, scopes_json, created_at FROM users `+where, args...)
 	var (
 		u         domain.User

--- a/internal/store/postgres/user_repository.go
+++ b/internal/store/postgres/user_repository.go
@@ -101,7 +101,7 @@ func (r UserRepository) UpdateScopes(ctx context.Context, id string, scopes []st
 // scanOne satisfies the corresponding ports method.
 func (r UserRepository) scanOne(ctx context.Context, where string, args ...any) (domain.User, error) {
 	row := r.db.QueryRowContext(ctx, fmt.Sprintf(`
-SELECT id, name, email, status, scopes_json::text, created_at FROM %s `+where, qualify(r.ns, "users")), args...) //nolint:gosec // G202: where is one of two literal constants
+SELECT id, name, email, status, scopes_json::text, created_at FROM %s `+where, qualify(r.ns, "users")), args...)
 	var (
 		u         domain.User
 		statusStr string

--- a/internal/store/sqlite/claim_repository.go
+++ b/internal/store/sqlite/claim_repository.go
@@ -222,7 +222,7 @@ SELECT DISTINCT c.id, c.text, c.type, c.confidence, c.status, c.created_at, c.cr
 FROM claims c
 JOIN claim_evidence ce ON ce.claim_id = c.id
 WHERE ce.event_id IN (%s)
-ORDER BY c.created_at ASC`, strings.Join(placeholders, ",")) //nolint:gosec // G201: placeholders are literal "?" strings, not user input
+ORDER BY c.created_at ASC`, strings.Join(placeholders, ","))
 
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -309,7 +309,7 @@ func (r ClaimRepository) ListEvidenceByClaimIDs(ctx context.Context, claimIDs []
 	query := fmt.Sprintf(`
 SELECT claim_id, event_id
 FROM claim_evidence
-WHERE claim_id IN (%s)`, strings.Join(placeholders, ",")) //nolint:gosec // G201: placeholders are literal "?" strings, not user input
+WHERE claim_id IN (%s)`, strings.Join(placeholders, ","))
 
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -351,7 +351,7 @@ func (r ClaimRepository) ListByIDs(ctx context.Context, claimIDs []string) ([]do
 	query := fmt.Sprintf(`
 SELECT id, text, type, confidence, status, created_at, created_by, trust_score, valid_from, valid_to, last_verified, verify_count, half_life_days, scope_service, scope_env, scope_team, source_document, source_type, source_authority, liveness, last_executed, citation_count, provenance_rationale, test_id, test_requirement_ref, test_author, test_last_modified, test_last_run_at, test_pass_count, test_fail_count, visibility, confidence_components
 FROM claims
-WHERE id IN (%s)`, strings.Join(placeholders, ",")) //nolint:gosec // G201: placeholders are literal "?" strings, not user input
+WHERE id IN (%s)`, strings.Join(placeholders, ","))
 
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/store/sqlite/event_repository.go
+++ b/internal/store/sqlite/event_repository.go
@@ -88,7 +88,7 @@ func (r EventRepository) ListByIDs(ctx context.Context, ids []string) ([]domain.
 	query := fmt.Sprintf(`
 SELECT id, run_id, schema_version, content, source_input_id, timestamp, metadata_json, ingested_at, created_by
 FROM events
-WHERE id IN (%s)`, strings.Join(placeholders, ",")) //nolint:gosec // G201: placeholders are literal "?" strings, not user input
+WHERE id IN (%s)`, strings.Join(placeholders, ","))
 
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/store/sqlite/relationship_repository.go
+++ b/internal/store/sqlite/relationship_repository.go
@@ -230,7 +230,6 @@ func (r RelationshipRepository) ListByClaimIDs(ctx context.Context, claimIDs []s
 	}
 	in := strings.Join(placeholders, ",")
 
-	//nolint:gosec // G201: placeholders are literal "?", IDs flow through ? bindings
 	q := "SELECT id, type, from_claim_id, to_claim_id, created_at, created_by FROM relationships WHERE from_claim_id IN (" + in + ") OR to_claim_id IN (" + in + ")"
 	rows, err := r.db.QueryContext(ctx, q, args...)
 	if err != nil {


### PR DESCRIPTION
## Drop gosec — security is owned by nox

The org has standardized on **nox** for security scanning (secrets + IaC + dependency + AI + taint-analysis SAST), replacing gosec at the code-lint layer. The golden config in `klarlabs-studio/.github` (`golangci.reference.yml`) already dropped gosec; this PR brings `mnemos` in line.

### Changes
- **`.golangci.yml`**: removed `gosec` from `linters.enable`, removed the `linters.settings.gosec` block (where present), and pruned gosec from `exclusions.rules` (dropping gosec-only rules entirely, removing the `gosec` token from mixed rules). Everything else — gocritic, the standard set, formatters, repo-specific config — is preserved unchanged.
- **Dead suppressions**: removed 32 now-unused gosec lint directives (`//nolint:gosec` / `// #nosec Gxxx`) that become dead once gosec is gone. For mixed `//nolint:errcheck,gosec` directives, only the `gosec` token was removed; the rest is kept.

### Verification
- `.golangci.yml` parses; no residual gosec references.
- `golangci-lint run ./...` (v2.12.2, the CI-pinned version) and `go build ./...` run locally.
- Removing gosec + its suppressions can only reduce lint findings.

No merge intended — opening for the Lint CI gate to confirm green.