### PR TITLE
feat(store): public provider packages for external consumers

### DIFF
--- a/libsql/libsql.go
+++ b/libsql/libsql.go
@@ -1,0 +1,12 @@
+// Package libsql registers mnemos's libsql storage provider with the store factory.
+//
+// Blank-import it so mnemos.New can open libsql:// DSNs:
+//
+//	import _ "go.klarlabs.de/mnemos/libsql"
+//
+// This is the public, externally-importable entry point for the provider whose
+// implementation lives under internal/store/libsql (which external modules cannot
+// import directly).
+package libsql
+
+import _ "go.klarlabs.de/mnemos/internal/store/libsql"

--- a/memory.go
+++ b/memory.go
@@ -37,7 +37,7 @@
 //
 //	import (
 //	    _ "go.klarlabs.de/mnemos/internal/store/memory"
-//	    _ "go.klarlabs.de/mnemos/internal/store/sqlite"
+//	    _ "go.klarlabs.de/mnemos/sqlite"
 //	    _ "go.klarlabs.de/mnemos/internal/store/postgres"
 //	)
 //

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -1,0 +1,12 @@
+// Package memory registers mnemos's memory storage provider with the store factory.
+//
+// Blank-import it so mnemos.New can open memory:// DSNs:
+//
+//	import _ "go.klarlabs.de/mnemos/memory"
+//
+// This is the public, externally-importable entry point for the provider whose
+// implementation lives under internal/store/memory (which external modules cannot
+// import directly).
+package memory
+
+import _ "go.klarlabs.de/mnemos/internal/store/memory"

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -1,0 +1,12 @@
+// Package mysql registers mnemos's mysql storage provider with the store factory.
+//
+// Blank-import it so mnemos.New can open mysql:// DSNs:
+//
+//	import _ "go.klarlabs.de/mnemos/mysql"
+//
+// This is the public, externally-importable entry point for the provider whose
+// implementation lives under internal/store/mysql (which external modules cannot
+// import directly).
+package mysql
+
+import _ "go.klarlabs.de/mnemos/internal/store/mysql"

--- a/new.go
+++ b/new.go
@@ -27,7 +27,7 @@ import (
 // The caller is responsible for blank-importing the storage providers
 // it needs. The simplest pattern:
 //
-//	import _ "go.klarlabs.de/mnemos/internal/store/sqlite"
+//	import _ "go.klarlabs.de/mnemos/sqlite"
 //
 // will let the default DSN resolve. For Postgres, MySQL, libSQL, or
 // in-memory storage, blank-import the corresponding sub-package.

--- a/options.go
+++ b/options.go
@@ -262,7 +262,7 @@ func WithLogger(logger *bolt.Logger) Option {
 // package must be blank-imported by the consuming program for the scheme
 // to be registered:
 //
-//	import _ "go.klarlabs.de/mnemos/internal/store/sqlite"
+//	import _ "go.klarlabs.de/mnemos/sqlite"
 //
 // Equivalent to WithStorage("sqlite://" + path). Passing an empty path is
 // a no-op (the default DSN resolution applies).

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -1,0 +1,12 @@
+// Package postgres registers mnemos's postgres storage provider with the store factory.
+//
+// Blank-import it so mnemos.New can open postgres:// DSNs:
+//
+//	import _ "go.klarlabs.de/mnemos/postgres"
+//
+// This is the public, externally-importable entry point for the provider whose
+// implementation lives under internal/store/postgres (which external modules cannot
+// import directly).
+package postgres
+
+import _ "go.klarlabs.de/mnemos/internal/store/postgres"

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -1,0 +1,12 @@
+// Package sqlite registers mnemos's sqlite storage provider with the store factory.
+//
+// Blank-import it so mnemos.New can open sqlite:// DSNs:
+//
+//	import _ "go.klarlabs.de/mnemos/sqlite"
+//
+// This is the public, externally-importable entry point for the provider whose
+// implementation lives under internal/store/sqlite (which external modules cannot
+// import directly).
+package sqlite
+
+import _ "go.klarlabs.de/mnemos/internal/store/sqlite"

--- a/sqlite/sqlite_test.go
+++ b/sqlite/sqlite_test.go
@@ -1,0 +1,35 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.klarlabs.de/mnemos"
+	_ "go.klarlabs.de/mnemos/sqlite"
+)
+
+// TestSQLiteProviderRegistered verifies that blank-importing the public sqlite
+// package is sufficient for an external caller to open a SQLite-backed store —
+// the registration the internal package performs is reachable through this
+// re-export.
+func TestSQLiteProviderRegistered(t *testing.T) {
+	mem, err := mnemos.New(mnemos.WithSQLite(filepath.Join(t.TempDir(), "m.db")))
+	if err != nil {
+		t.Fatalf("New with sqlite provider: %v", err)
+	}
+	defer func() { _ = mem.Close() }()
+
+	ctx := context.Background()
+	if err := mem.RememberEvent(ctx, mnemos.Event{ID: "e1", At: time.Now(), Type: "deployment", Content: "deployed v1"}); err != nil {
+		t.Fatalf("RememberEvent: %v", err)
+	}
+	id, err := mem.RememberClaim(ctx, mnemos.ClaimItem{Text: "service runs v1", EventIDs: []string{"e1"}})
+	if err != nil {
+		t.Fatalf("RememberClaim: %v", err)
+	}
+	if id == "" {
+		t.Fatal("empty claim id")
+	}
+}


### PR DESCRIPTION
Storage providers live under `internal/store/*` and self-register via `init()`. External modules can't blank-import `internal/`, so `mnemos.New()` failed with `unknown provider "sqlite"` for any downstream consumer. Adds public re-export packages (`go.klarlabs.de/mnemos/{sqlite,memory,postgres,mysql,libsql}`) — the database/sql driver idiom — plus a registration test.

Surfaced while building the platform (Grace) on mnemos: `cmd/runtime` could not open its embedded SQLite store.

https://claude.ai/code/session_01Cah5LkQHbpxog74NLpujQ9